### PR TITLE
Add extra connections for nodes

### DIFF
--- a/announce/announcer.go
+++ b/announce/announcer.go
@@ -181,20 +181,24 @@ func determineConnections(log *logger.L) {
 	}
 
 	for i, node := range toConnectNode {
-		if node == globalData.thisNode || node == globalData.n1 || node == globalData.n3 {
-			continue
-		}
-		if node == nil {
-			fmt.Printf("No.%d of toConnectNode is nil : %+v. Node level is : %d", i, toConnectNode, nodeDepth)
+		nodeLabel := fmt.Sprintf("X%d", (i+1)*25) // it should by X25, X50 and X75
+		if nil == node {
+			log.Warnf("The node of %s is nil. This should not be happended.", nodeLabel)
 			continue
 		}
 
-		peer := node.Value().(*peerEntry)
-		priority := fmt.Sprintf("X%d", (i+1)*25)
-		log.Infof("%s: this: %x", priority, globalData.publicKey)
-		log.Infof("%s: peer: %x", priority, peer)
-		messagebus.Bus.Subscriber.Send(priority, peer.publicKey, peer.broadcasts)
-		messagebus.Bus.Connector.Send(priority, peer.publicKey, peer.listeners)
+		if node == globalData.thisNode || node == globalData.n1 || node == globalData.n3 {
+			continue
+		}
+
+		if n := globalData.crossNodes[nodeLabel]; n != node {
+			globalData.crossNodes[nodeLabel] = node
+			peer := node.Value().(*peerEntry)
+			log.Infof("%s: this: %x", nodeLabel, globalData.publicKey)
+			log.Infof("%s: peer: %x", nodeLabel, peer)
+			messagebus.Bus.Subscriber.Send(nodeLabel, peer.publicKey, peer.broadcasts)
+			messagebus.Bus.Connector.Send(nodeLabel, peer.publicKey, peer.listeners)
+		}
 	}
 	// ***** FIX THIS:   possible treat key as a number and compute; assuming uniformly distributed keys
 	// ***** FIX THIS:   but would need the tree search to be able to find the "next highest/lowest key" for this to work

--- a/announce/setup.go
+++ b/announce/setup.go
@@ -58,6 +58,8 @@ type announcerData struct {
 	n1 *avl.Node // first neighbour
 	n3 *avl.Node // third neighbour
 
+	crossNodes map[string]*avl.Node // map of cross nodes
+
 	// database of all RPCs
 	rpcIndex map[fingerprintType]int // index to find rpc entry
 	rpcList  []*rpcEntry             // array of RPCs
@@ -98,6 +100,7 @@ func Initialise(nodesDomain string) error {
 	globalData.thisNode = nil
 	globalData.change = false
 
+	globalData.crossNodes = make(map[string]*avl.Node, 3)
 	globalData.rpcIndex = make(map[fingerprintType]int, 1000)
 	globalData.rpcList = make([]*rpcEntry, 0, 1000)
 

--- a/announce/setup.go
+++ b/announce/setup.go
@@ -67,6 +67,9 @@ type announcerData struct {
 	// data for thread
 	ann announcer
 
+	// the peer in last broadcast
+	lastBroadcastPeer int
+
 	// for background
 	background *background.T
 

--- a/avl/avl_test.go
+++ b/avl/avl_test.go
@@ -384,3 +384,87 @@ func TestOverwriteAndNodeStability(t *testing.T) {
 		t.Fatalf("inconsistant tree")
 	}
 }
+
+func TestGetDepthInTree(t *testing.T) {
+	addList := []stringItem{
+		{"01"}, {"02"}, {"03"}, {"04"}, {"05"},
+		{"06"}, {"07"},
+	}
+
+	tree := avl.New()
+	for _, key := range addList {
+		tree.Insert(key, "data:"+key.String())
+	}
+
+	if d := tree.First().Next().Depth(); d != 1 {
+		t.Fatalf("incorrect node depth: %d", d)
+	}
+
+	if d := tree.First().Next().Next().Depth(); d != 2 {
+		t.Fatalf("incorrect node depth: %d", d)
+	}
+}
+
+func TestGetChildrenByDepth(t *testing.T) {
+	addList := []stringItem{
+		{"01"}, {"02"}, {"03"}, {"04"}, {"05"},
+		{"06"}, {"07"},
+	}
+
+	tree := avl.New()
+	for _, key := range addList {
+		tree.Insert(key, "data:"+key.String())
+	}
+
+	if len(tree.Root().GetChildrenByDepth(1)) != 2 {
+		t.Fatalf("incorrect children numner in depth 1")
+
+	}
+
+	if len(tree.Root().GetChildrenByDepth(2)) != 4 {
+		t.Fatalf("incorrect children numner in depth 2")
+	}
+}
+
+func TestGetOrderInTree(t *testing.T) {
+	addList := []stringItem{
+		{"01"}, {"02"}, {"03"}, {"04"}, {"05"},
+		{"06"}, {"07"},
+	}
+
+	tree := avl.New()
+	for _, key := range addList {
+		tree.Insert(key, "data:"+key.String())
+	}
+
+	nodeOrder := tree.Root().GetOrder(stringItem{"03"})
+	if nodeOrder != 2 {
+		t.Fatalf("incorrect node order: %d", nodeOrder)
+	}
+	nodeOrder = tree.Root().GetOrder(stringItem{"05"})
+	if nodeOrder != 4 {
+		t.Fatalf("incorrect node order: %d", nodeOrder)
+	}
+}
+
+func TestGetNodeByOrderInTree(t *testing.T) {
+	addList := []stringItem{
+		{"01"}, {"02"}, {"03"}, {"04"}, {"05"},
+		{"06"}, {"07"},
+	}
+
+	tree := avl.New()
+	for _, key := range addList {
+		tree.Insert(key, "data:"+key.String())
+	}
+
+	node := tree.Root().GetNodeByOrder(4)
+	if node.Key().Compare(stringItem{"05"}) != 0 {
+		t.Fatalf("incorrect node get: %+v", node)
+	}
+
+	node = tree.Root().GetNodeByOrder(3)
+	if node.Key().Compare(stringItem{"04"}) != 0 {
+		t.Fatalf("incorrect node get: %+v", node)
+	}
+}

--- a/avl/search.go
+++ b/avl/search.go
@@ -23,3 +23,29 @@ func search(key item, tree *Node) *Node {
 		return tree
 	}
 }
+
+// get the order of a node with a specific key in a tree
+func (p *Node) GetOrder(key item) uint {
+	iterNode := p.first()
+	lastKey := p.last().Key()
+	order := uint(0)
+
+	for iterNode.Key().Compare(key) != 0 && iterNode.Key().Compare(lastKey) != 0 {
+		order += 1
+		iterNode = iterNode.Next()
+	}
+
+	return order
+}
+
+// get the node of a tree in order
+func (p *Node) GetNodeByOrder(order uint) *Node {
+	node := p.first()
+	for i := uint(0); i < order; i++ {
+		if node == p.last() {
+			break
+		}
+		node = node.Next()
+	}
+	return node
+}

--- a/avl/setup.go
+++ b/avl/setup.go
@@ -28,6 +28,31 @@ func (tree *Tree) Count() int {
 	return tree.count
 }
 
+// Root return the root node of the tree
+func (tree *Tree) Root() *Node {
+	return tree.root
+}
+
+// GetChildrenByDepth will returns all children in a specific depth of a tree
+func (p *Node) GetChildrenByDepth(depth uint) []*Node {
+	nodes := []*Node{}
+
+	if depth == 0 {
+		nodes = []*Node{p}
+	} else {
+		left := p.left
+		right := p.right
+		if left != nil {
+			nodes = append(nodes, left.GetChildrenByDepth(depth-1)...)
+		}
+
+		if right != nil {
+			nodes = append(nodes, right.GetChildrenByDepth(depth-1)...)
+		}
+	}
+	return nodes
+}
+
 // read the key from a node
 func (p *Node) Key() item {
 	return p.key
@@ -36,4 +61,20 @@ func (p *Node) Key() item {
 // read the value from a node
 func (p *Node) Value() interface{} {
 	return p.value
+}
+
+// return parent node of a node
+func (p *Node) Parent() *Node {
+	return p.up
+}
+
+// get the depth of a node
+func (p *Node) Depth() uint {
+	count := uint(0)
+	parent := p.up
+	for parent != nil {
+		count += 1
+		parent = parent.up
+	}
+	return count
 }


### PR DESCRIPTION
The main idea is to search nodes in trees whose depth are 2.

If a node is located in a depth 2 subtree, we calc the order of the node in the tree. Then, we try to finds nodes with the same order in the rest of sibling depth 2 trees and connects to them.

Besides, to ensure that each nodes could have a whole view of all nodes. We broadcast nodes in a round-robin manner so every nodes can eventually get all its peers in a network.