### PR TITLE
Return nil for readability

### DIFF
--- a/peer/client.go
+++ b/peer/client.go
@@ -101,5 +101,5 @@ dynamicScan:
 	if nil != err {
 		log.Errorf("ConnectTo: %x @ %s  error: %v", serverPublicKey, *address, err)
 	}
-	return nil
+	return err
 }

--- a/peer/client.go
+++ b/peer/client.go
@@ -101,5 +101,5 @@ dynamicScan:
 	if nil != err {
 		log.Errorf("ConnectTo: %x @ %s  error: %v", serverPublicKey, *address, err)
 	}
-	return err
+	return nil
 }

--- a/rpc/node.go
+++ b/rpc/node.go
@@ -45,7 +45,7 @@ func (node *Node) List(arguments *NodeArguments, reply *NodeReply) error {
 	reply.Nodes = nodes
 	reply.NextStart = nextStart
 
-	return err
+	return nil
 }
 
 // return some information about this node


### PR DESCRIPTION
`return err` -> `return nil`

In this case `err` is a `nil` type anyways, might as well just return `nil`.