### PR TITLE
Change log level of tcp events into debug

### DIFF
--- a/payment/background.go
+++ b/payment/background.go
@@ -149,7 +149,7 @@ func (d *discoverer) Run(args interface{}, shutdown <-chan struct{}) {
 						d.log.Errorf("receive event error: %s", err)
 						continue loop
 					}
-					d.log.Infof("event: %q  address: %q  value: %d", ev, addr, v)
+					d.log.Debugf("event: %q  address: %q  value: %d", ev, addr, v)
 					retrieve <- struct{}{}
 				default:
 					msg, err := s.RecvMessageBytes(0)

--- a/peer/listener.go
+++ b/peer/listener.go
@@ -290,7 +290,7 @@ func (lstn *listener) handleEvent(socket *zmq.Socket) {
 		lstn.log.Errorf("receive event error: %s", err)
 		return
 	}
-	lstn.log.Infof("event: %q  address: %q  value: %d", ev, addr, v)
+	lstn.log.Debugf("event: %q  address: %q  value: %d", ev, addr, v)
 
 	switch ev {
 	case zmq.EVENT_ACCEPTED:


### PR DESCRIPTION
The log level of tcp events should belong to debug. The info log should be normal information. Put this messages in will make info level be useless.

