### PR TITLE
fix gen-proof-identity command

### DIFF
--- a/command/bitmarkd/bitmarkd.conf.sample
+++ b/command/bitmarkd/bitmarkd.conf.sample
@@ -192,7 +192,7 @@ M.proofing = {
 
     public_key = read_file("proof.public"),
     private_key = read_file("proof.private"),
-    signing_key = read_file("proof.sign"),
+    signing_key = read_file(M.chain == "bitmark" and 'proof.live' or 'proof.test'),
 
     -- payments for future transfers
     -- private keys are just samples for testing


### PR DESCRIPTION
1. `gen-proof-identity` will generate signing keys for both livenet and testnet
2. The lua config can read the required one based on `M.chain` (Reference: http://lua-users.org/wiki/TernaryOperator)