### PR TITLE
[Bitmarkd] Add latest block hash in HTTP and RPC response

### DIFF
--- a/block/setup.go
+++ b/block/setup.go
@@ -6,6 +6,7 @@ package block
 
 import (
 	"encoding/binary"
+	"encoding/hex"
 	"reflect"
 	"sync"
 
@@ -291,4 +292,23 @@ func Finalise() error {
 	globalData.log.Flush()
 
 	return nil
+}
+
+// return the last block hash in hex string if found
+func LastBlockHash() string {
+
+	log := globalData.log
+
+	if last, ok := storage.Pool.Blocks.LastElement(); ok {
+
+		_, digest, _, err := blockrecord.ExtractHeader(last.Value)
+		if nil != err {
+			log.Criticalf("failed to unpack block: %d from storage error: %s", binary.BigEndian.Uint64(last.Key), err)
+			return ""
+		}
+
+		return hex.EncodeToString(digest[:])
+	}
+
+	return ""
 }

--- a/block/setup.go
+++ b/block/setup.go
@@ -6,7 +6,6 @@ package block
 
 import (
 	"encoding/binary"
-	"encoding/hex"
 	"reflect"
 	"sync"
 
@@ -307,7 +306,7 @@ func LastBlockHash() string {
 			return ""
 		}
 
-		return hex.EncodeToString(digest[:])
+		return digest.String()
 	}
 
 	return ""

--- a/command/bitmark-cli/rpccalls/grant.go
+++ b/command/bitmark-cli/rpccalls/grant.go
@@ -61,7 +61,7 @@ func (client *Client) Grant(grantConfig *GrantData) (*GrantSingleSignedReply, er
 		if nil != err {
 			return nil, err
 		}
-		grantConfig.BeforeBlock = info.Blocks + 100 // allow plenty of time to mine
+		grantConfig.BeforeBlock = info.Blocks.Height + 100 // allow plenty of time to mine
 	}
 
 	packed, grant, err := makeGrantOneSignature(client.testnet, shareId, grantConfig.Quantity, grantConfig.Owner, grantConfig.Recipient, grantConfig.BeforeBlock)

--- a/command/bitmark-cli/rpccalls/swap.go
+++ b/command/bitmark-cli/rpccalls/swap.go
@@ -69,7 +69,7 @@ func (client *Client) Swap(swapConfig *SwapData) (*SwapSingleSignedReply, error)
 		if nil != err {
 			return nil, err
 		}
-		swapConfig.BeforeBlock = info.Blocks + 100 // allow plenty of time to mine
+		swapConfig.BeforeBlock = info.Blocks.Height + 100 // allow plenty of time to mine
 	}
 
 	packed, swap, err := makeSwapOneSignature(client.testnet, shareIdOne, swapConfig.QuantityOne, swapConfig.OwnerOne, shareIdTwo, swapConfig.QuantityTwo, swapConfig.OwnerTwo, swapConfig.BeforeBlock)

--- a/rpc/httphandler.go
+++ b/rpc/httphandler.go
@@ -141,8 +141,8 @@ func (s *httpHandler) details(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type blockInfo struct {
-		LRCount    lrCount `json:"lr_count"`
-		LatestHash string  `json:"latest_hash"`
+		LRCount lrCount `json:"lr_count"`
+		Hash    string  `json:"hash"`
 	}
 
 	type peerCounts struct {
@@ -171,7 +171,7 @@ func (s *httpHandler) details(w http.ResponseWriter, r *http.Request) {
 				Local:  blockheader.Height(),
 				Remote: peer.BlockHeight(),
 			},
-			LatestHash: block.LastBlockHash(),
+			Hash: block.LastBlockHash(),
 		},
 		RPCs: connectionCount.Uint64(),
 		// Miners : mine.ConnectionCount(),

--- a/rpc/httphandler.go
+++ b/rpc/httphandler.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/bitmark-inc/bitmarkd/announce"
+	"github.com/bitmark-inc/bitmarkd/block"
 	"github.com/bitmark-inc/bitmarkd/blockheader"
 	"github.com/bitmark-inc/bitmarkd/difficulty"
 	"github.com/bitmark-inc/bitmarkd/mode"
@@ -139,6 +140,11 @@ func (s *httpHandler) details(w http.ResponseWriter, r *http.Request) {
 		Remote uint64 `json:"remote"`
 	}
 
+	type blockInfo struct {
+		LRCount    lrCount `json:"lr_count"`
+		LatestHash string  `json:"latest_hash"`
+	}
+
 	type peerCounts struct {
 		Incoming uint64 `json:"incoming"`
 		Outgoing uint64 `json:"outgoing"`
@@ -147,7 +153,7 @@ func (s *httpHandler) details(w http.ResponseWriter, r *http.Request) {
 	type theReply struct {
 		Chain               string     `json:"chain"`
 		Mode                string     `json:"mode"`
-		Blocks              lrCount    `json:"blocks"`
+		Blocks              blockInfo  `json:"blocks"`
 		RPCs                uint64     `json:"rpcs"`
 		Peers               peerCounts `json:"peers"`
 		TransactionCounters Counters   `json:"transactionCounters"`
@@ -160,9 +166,12 @@ func (s *httpHandler) details(w http.ResponseWriter, r *http.Request) {
 	reply := theReply{
 		Chain: mode.ChainName(),
 		Mode:  mode.String(),
-		Blocks: lrCount{
-			Local:  blockheader.Height(),
-			Remote: peer.BlockHeight(),
+		Blocks: blockInfo{
+			LRCount: lrCount{
+				Local:  blockheader.Height(),
+				Remote: peer.BlockHeight(),
+			},
+			LatestHash: block.LastBlockHash(),
 		},
 		RPCs: connectionCount.Uint64(),
 		// Miners : mine.ConnectionCount(),

--- a/rpc/node.go
+++ b/rpc/node.go
@@ -8,6 +8,8 @@ import (
 	"encoding/hex"
 	"time"
 
+	"github.com/bitmark-inc/bitmarkd/block"
+
 	"golang.org/x/time/rate"
 
 	"github.com/bitmark-inc/bitmarkd/announce"
@@ -63,17 +65,22 @@ func (node *Node) List(arguments *NodeArguments, reply *NodeReply) error {
 
 type InfoArguments struct{}
 
+type blockInfo struct {
+	Height     uint64 `json:"height"`
+	LatestHash string `json:"latest_hash"`
+}
+
 type InfoReply struct {
-	Chain               string   `json:"chain"`
-	Mode                string   `json:"mode"`
-	Blocks              uint64   `json:"blocks"`
-	RPCs                uint64   `json:"rpcs"`
-	Peers               uint64   `json:"peers"`
-	TransactionCounters Counters `json:"transactionCounters"`
-	Difficulty          float64  `json:"difficulty"`
-	Version             string   `json:"version"`
-	Uptime              string   `json:"uptime"`
-	PublicKey           string   `json:"publicKey"`
+	Chain               string    `json:"chain"`
+	Mode                string    `json:"mode"`
+	Blocks              blockInfo `json:"blocks"`
+	RPCs                uint64    `json:"rpcs"`
+	Peers               uint64    `json:"peers"`
+	TransactionCounters Counters  `json:"transactionCounters"`
+	Difficulty          float64   `json:"difficulty"`
+	Version             string    `json:"version"`
+	Uptime              string    `json:"uptime"`
+	PublicKey           string    `json:"publicKey"`
 }
 
 type Counters struct {
@@ -90,7 +97,10 @@ func (node *Node) Info(arguments *InfoArguments, reply *InfoReply) error {
 	incoming, outgoing := peer.GetCounts()
 	reply.Chain = mode.ChainName()
 	reply.Mode = mode.String()
-	reply.Blocks = blockheader.Height()
+	reply.Blocks = blockInfo{
+		Height:     blockheader.Height(),
+		LatestHash: block.LastBlockHash(),
+	}
 	reply.RPCs = connectionCount.Uint64()
 	reply.Peers = incoming + outgoing
 	reply.TransactionCounters.Pending, reply.TransactionCounters.Verified = reservoir.ReadCounters()

--- a/rpc/node.go
+++ b/rpc/node.go
@@ -66,8 +66,8 @@ func (node *Node) List(arguments *NodeArguments, reply *NodeReply) error {
 type InfoArguments struct{}
 
 type BlockInfo struct {
-	Height     uint64 `json:"height"`
-	LatestHash string `json:"latest_hash"`
+	Height uint64 `json:"height"`
+	Hash   string `json:"hash"`
 }
 
 type InfoReply struct {
@@ -98,8 +98,8 @@ func (node *Node) Info(arguments *InfoArguments, reply *InfoReply) error {
 	reply.Chain = mode.ChainName()
 	reply.Mode = mode.String()
 	reply.Blocks = BlockInfo{
-		Height:     blockheader.Height(),
-		LatestHash: block.LastBlockHash(),
+		Height: blockheader.Height(),
+		Hash:   block.LastBlockHash(),
 	}
 	reply.RPCs = connectionCount.Uint64()
 	reply.Peers = incoming + outgoing

--- a/rpc/node.go
+++ b/rpc/node.go
@@ -65,7 +65,7 @@ func (node *Node) List(arguments *NodeArguments, reply *NodeReply) error {
 
 type InfoArguments struct{}
 
-type blockInfo struct {
+type BlockInfo struct {
 	Height     uint64 `json:"height"`
 	LatestHash string `json:"latest_hash"`
 }
@@ -73,7 +73,7 @@ type blockInfo struct {
 type InfoReply struct {
 	Chain               string    `json:"chain"`
 	Mode                string    `json:"mode"`
-	Blocks              blockInfo `json:"blocks"`
+	Blocks              BlockInfo `json:"blocks"`
 	RPCs                uint64    `json:"rpcs"`
 	Peers               uint64    `json:"peers"`
 	TransactionCounters Counters  `json:"transactionCounters"`
@@ -97,7 +97,7 @@ func (node *Node) Info(arguments *InfoArguments, reply *InfoReply) error {
 	incoming, outgoing := peer.GetCounts()
 	reply.Chain = mode.ChainName()
 	reply.Mode = mode.String()
-	reply.Blocks = blockInfo{
+	reply.Blocks = BlockInfo{
 		Height:     blockheader.Height(),
 		LatestHash: block.LastBlockHash(),
 	}


### PR DESCRIPTION
This PR do the following
- Add latest block hash to response in HTTP API `bitmarkd/details`
- Add latest block hash to response in RPC call `Node.Info`