### PR TITLE
[bitmarkd] Active connection timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 *.swp
 TAGS
 tags
+.vscode/
 
 # LOG
 *.log

--- a/announce/nodeslookup.go
+++ b/announce/nodeslookup.go
@@ -1,0 +1,153 @@
+package announce
+
+import (
+	"net"
+	"strings"
+	"time"
+
+	"github.com/bitmark-inc/bitmarkd/fault"
+
+	"github.com/bitmark-inc/bitmarkd/util"
+	"github.com/bitmark-inc/logger"
+	"github.com/miekg/dns"
+)
+
+const (
+	timeInterval = 1 * time.Hour // time interval for re-fetching nodes domain
+)
+
+type nodesLookup struct {
+	logger *logger.L
+
+	nodesDomain string
+}
+
+func (n *nodesLookup) initialise(nodesDomain string) error {
+
+	n.logger = logger.New("nodeslookup")
+	n.logger.Info("initialising…")
+	n.nodesDomain = nodesDomain
+
+	return lookupNodesDomain(n.nodesDomain, n.logger)
+}
+
+func (n *nodesLookup) Run(args interface{}, shutdown <-chan struct{}) {
+
+	timer := time.After(getIntervalTime(n.nodesDomain, n.logger))
+
+loop:
+	for {
+		select {
+		case <-timer:
+			timer = time.After(getIntervalTime(n.nodesDomain, n.logger))
+			lookupNodesDomain(n.nodesDomain, n.logger)
+
+		case <-shutdown:
+			break loop
+		}
+	}
+}
+
+// get interval time for lookup node domain txt record
+func getIntervalTime(domain string, log *logger.L) time.Duration {
+
+	t := timeInterval
+
+	// reading default configuration file
+	configFile := "/etc/resolv.conf"
+	conf, err := dns.ClientConfigFromFile(configFile)
+
+	if nil != err {
+		log.Errorf("reading %s error: %s", configFile, err)
+		return t
+	}
+
+	if 0 == len(conf.Servers) {
+		log.Errorf("cannot get dns name server")
+		return t
+	}
+
+	server := net.JoinHostPort(conf.Servers[0], conf.Port) // use the first dns name server
+	log.Debugf("DNS Name server: %s", server)
+	c := dns.Client{}
+	msg := dns.Msg{}
+	msg.SetQuestion(domain+".", dns.TypeSOA) // fixed for type SOA
+
+	r, _, err := c.Exchange(&msg, server)
+	if nil != err {
+		log.Errorf("exchange with dns server error: %s", err)
+		return t
+	}
+
+	if 0 == len(r.Ns) {
+		log.Errorf("dns response has no authority section")
+		return t
+	}
+
+	for _, ns := range r.Ns {
+		if a, ok := ns.(*dns.SOA); ok {
+			ttl := a.Hdr.Ttl
+			if 0 < ttl {
+				log.Infof("TTL record: %d", ttl)
+				ttlSec := time.Duration(ttl) * time.Second
+				if timeInterval > ttlSec {
+					t = ttlSec
+				}
+			}
+		}
+	}
+
+	log.Infof("time to re-fetching node domain: %v", t)
+	return t
+}
+
+// lookup node domain for the peering
+func lookupNodesDomain(domain string, log *logger.L) error {
+
+	if "" == domain {
+		log.Error("invalid node domain")
+		return fault.InvalidError("invalid node domain")
+	}
+
+	texts, err := net.LookupTXT(domain)
+	if nil != err {
+		log.Errorf("lookup TXT record error: %s", err)
+		return err
+	}
+
+	// process DNS entries
+	for i, t := range texts {
+		t = strings.TrimSpace(t)
+		tag, err := parseTag(t)
+		if nil != err {
+			log.Infof("ignore TXT[%d]: %q  error: %s", i, t, err)
+		} else {
+			log.Infof("process TXT[%d]: %q", i, t)
+			log.Infof("result[%d]: IPv4: %q  IPv6: %q  rpc: %d  connect: %d", i, tag.ipv4, tag.ipv6, tag.rpcPort, tag.connectPort)
+			log.Infof("result[%d]: peer public key: %x", i, tag.publicKey)
+			log.Infof("result[%d]: rpc fingerprint: %x", i, tag.certificateFingerprint)
+
+			listeners := []byte{}
+
+			if nil != tag.ipv4 {
+				c1 := util.ConnectionFromIPandPort(tag.ipv4, tag.connectPort)
+				listeners = append(listeners, c1.Pack()...)
+			}
+			if nil != tag.ipv6 {
+				c2 := util.ConnectionFromIPandPort(tag.ipv6, tag.connectPort)
+				listeners = append(listeners, c2.Pack()...)
+			}
+
+			if nil == tag.ipv4 && nil == tag.ipv6 {
+				log.Debugf("result[%d]: ignoring invalid record", i)
+			} else {
+				log.Infof("result[%d]: adding: %x", i, listeners)
+
+				// internal add, as lock is already held
+				addPeer(tag.publicKey, listeners, 0)
+			}
+		}
+	}
+
+	return nil
+}

--- a/announce/nodeslookup.go
+++ b/announce/nodeslookup.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2019 Bitmark Inc.
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
 package announce
 
 import (

--- a/announce/peer.go
+++ b/announce/peer.go
@@ -23,7 +23,7 @@ type pubkey []byte
 type peerEntry struct {
 	publicKey []byte
 	listeners []byte
-	timestamp time.Time
+	timestamp time.Time // last seen time
 }
 
 // string - conversion fro fmt package
@@ -179,4 +179,20 @@ func (p pubkey) Compare(q interface{}) int {
 // String - public key string convert for AVL interface
 func (p pubkey) String() string {
 	return fmt.Sprintf("%x", []byte(p))
+}
+
+// SetPeerTimestamp - set the timestamp for the peer with given public key
+func SetPeerTimestamp(publicKey []byte, timestamp time.Time) {
+	globalData.Lock()
+	defer globalData.Unlock()
+
+	node, _ := globalData.peerTree.Search(pubkey(publicKey))
+	log := globalData.log
+	if nil == node {
+		log.Errorf("The peer with public key %x is not existing in peer tree", publicKey)
+		return
+	}
+
+	peer := node.Value().(*peerEntry)
+	peer.timestamp = timestamp
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 	github.com/golang/protobuf v1.3.1 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
+	github.com/miekg/dns v1.1.9
+	github.com/miekg/exdns v0.0.0-20180508064346-75eec86f1dd5 // indirect
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
 	github.com/onsi/ginkgo v1.8.0 // indirect
 	github.com/onsi/gomega v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,10 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/miekg/dns v1.1.9 h1:OIdC9wT96RzuZMf2PfKRhFgsStHUUBZLM/lo1LqiM9E=
+github.com/miekg/dns v1.1.9/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/miekg/exdns v0.0.0-20180508064346-75eec86f1dd5 h1:BYk/0wGb4gYRWiuqITqimZ7IZKGobA6SXbzf79R/Dv4=
+github.com/miekg/exdns v0.0.0-20180508064346-75eec86f1dd5/go.mod h1:4uMTEQT5j7VkoIf87GPzK4zXPP8hv+fB5+SML8gFiVU=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/peer/upstream/setup.go
+++ b/peer/upstream/setup.go
@@ -201,7 +201,7 @@ func (u *Upstream) Ping() (success bool) {
 	u.Unlock()
 
 	if nil != err {
-		u.log.Errorf("Ping to server %s failed with error %s", u.client, err)
+		u.log.Errorf("ping to server %s failed with error %s", u.client, err)
 		return
 	}
 
@@ -212,7 +212,7 @@ func (u *Upstream) Ping() (success bool) {
 	switch string(data[0]) {
 	case "P":
 		// Ping to peer successfully
-		u.log.Infof("Ping to server %s success", u.client)
+		u.log.Infof("ping to server %s success", u.client)
 		success = true
 	default:
 	}


### PR DESCRIPTION
This PR do following:

- [x] Ping to all servers to check the connection is active once per minute. If success, modify the `timestamp` in `peerEntry` in AVL tree corresponding to the server to make it will not be expired.

- [x] Running background task to get the TTL record from nodes domain to determine the time interval to re-fetching the TXT records for the peer connections AVL tree.

Reference: https://bitmarkinc.monday.com/boards/215309468/pulses/212067159