### PR TITLE
[bitmarkd] Queue overflow in peer protocol

### DIFF
--- a/messagebus/queue.go
+++ b/messagebus/queue.go
@@ -168,7 +168,7 @@ func (queue *BroadcastQueue) Chan(size int) <-chan Message {
 	return c
 }
 
-// Release - release the incomming and outgoing queues
+// Release - release the incomming and outgoing queue
 func (queue *BroadcastQueue) Release() {
 	// close all channel
 	close(queue.in)
@@ -181,7 +181,7 @@ func (queue *BroadcastQueue) Release() {
 	queue.out = make([]chan Message, 0, 10)
 }
 
-// DropCache - drop the item from cache
+// DropCache - drop the items from cache
 func (queue *BroadcastQueue) DropCache(msgs ...Message) {
 
 	if nil == msgs {
@@ -201,21 +201,18 @@ func (queue *BroadcastQueue) DropCache(msgs ...Message) {
 	}
 }
 
-// clear the cache
 func (queue *BroadcastQueue) clearCache() {
 	queue.Lock()
 	defer queue.Unlock()
 	queue.deliveredMessage = map[string]Message{}
 }
 
-// cache the delivered message
 func (queue *BroadcastQueue) cache(m Message) {
 	queue.Lock()
 	defer queue.Unlock()
 	queue.deliveredMessage[m.packHex()] = m
 }
 
-// check whether Message is cached
 func (queue *BroadcastQueue) isCached(m Message) bool {
 	queue.RLock()
 	defer queue.RUnlock()

--- a/messagebus/queue_test.go
+++ b/messagebus/queue_test.go
@@ -5,6 +5,7 @@
 package messagebus_test
 
 import (
+	"math/rand"
 	"sync"
 	"testing"
 	"time"
@@ -108,4 +109,76 @@ func TestBroadcast(t *testing.T) {
 			t.Errorf("listener[%d] received: %d  expected: %d", i, n, len(items))
 		}
 	}
+}
+
+func TestCache(t *testing.T) {
+
+	cacheableCmd := []string{"assets", "issues", "transfer", "proof", "block"}
+	uncacheableCmd := []string{"rpc", "peer"}
+	c1 := cacheableCmd[rand.Intn(len(cacheableCmd))]
+	c2 := uncacheableCmd[rand.Intn(len(uncacheableCmd))]
+	c := []string{c1, c2}
+	p := make([]byte, 0)
+
+	// declare listener
+	queue := messagebus.Bus.Broadcast.Chan(50)
+
+	// send a message is not delivered before
+	for _, cmd := range c {
+		messagebus.Bus.Broadcast.Send(cmd, p)
+	}
+	time.Sleep(20 * time.Millisecond)
+
+	for i := 0; i < len(c); i += 1 {
+		select {
+		case received := <-queue:
+			if received.Command != c[i] {
+				t.Errorf("actual command : %q, expected: %q", received.Command, c[i])
+			}
+		default:
+			t.Errorf("expect message received but nothing received")
+		}
+	}
+
+	// func to check whether a string is contained in an array string
+	f := func(a []string, i string) bool {
+		for _, item := range a {
+			if item == i {
+				return true
+			}
+		}
+		return false
+	}
+
+	// try to send it again
+	for _, cmd := range c {
+		messagebus.Bus.Broadcast.Send(cmd, p)
+	}
+	time.Sleep(20 * time.Millisecond)
+
+	for i := 0; i < len(c); i += 1 {
+		select {
+		case received := <-queue:
+			if !f(uncacheableCmd, received.Command) {
+				t.Errorf("actual: %q, expected in %q", received.Command, uncacheableCmd)
+			}
+		default:
+		}
+	}
+
+	// drop cache and resend it
+	params := make([][]byte, 0)
+	messagebus.DropCache(messagebus.Message{Command: c1, Parameters: params})
+	messagebus.Bus.Broadcast.Send(c1, p)
+	time.Sleep(20 * time.Millisecond)
+
+	select {
+	case received := <-queue:
+		if received.Command != c1 {
+			t.Errorf("actual command : %q, expected: %q", received.Command, c1)
+		}
+	default:
+		t.Errorf("actual nothing but expected is %q", c1)
+	}
+
 }

--- a/peer/upstream/setup.go
+++ b/peer/upstream/setup.go
@@ -25,7 +25,6 @@ import (
 
 const (
 	cycleInterval = 30 * time.Second
-	queueSize     = 50 // 0 => synchronous queue
 )
 
 // Upstream - structure to hold an upstream connection
@@ -225,7 +224,8 @@ func upstreamRunner(u *Upstream, shutdown <-chan struct{}) {
 
 	log.Debug("starting…")
 
-	queue := messagebus.Bus.Broadcast.Chan(queueSize)
+	// use default queue size
+	queue := messagebus.Bus.Broadcast.Chan(-1)
 
 	timer := time.After(cycleInterval)
 

--- a/peer/upstream/setup.go
+++ b/peer/upstream/setup.go
@@ -381,7 +381,7 @@ func push(client *zmqutil.Client, log *logger.L, item *messagebus.Message) error
 	if nil != err {
 		log.Errorf("push: %s send error: %s", client, err)
 		// Drop the message from cache for retrying later
-		messagebus.DropCache(*item)
+		messagebus.Bus.Broadcast.DropCache(*item)
 		return err
 	}
 

--- a/peer/upstream/setup.go
+++ b/peer/upstream/setup.go
@@ -380,6 +380,8 @@ func push(client *zmqutil.Client, log *logger.L, item *messagebus.Message) error
 	err := client.Send(item.Command, item.Parameters)
 	if nil != err {
 		log.Errorf("push: %s send error: %s", client, err)
+		// Drop the message from cache for retrying later
+		messagebus.DropCache(*item)
 		return err
 	}
 

--- a/publish/broadcaster.go
+++ b/publish/broadcaster.go
@@ -123,11 +123,15 @@ func (brdc *broadcaster) process(socket *zmq.Socket, item *messagebus.Message) e
 
 	_, err := socket.Send(brdc.chain, zmq.SNDMORE|zmq.DONTWAIT)
 	if nil != err {
+		// Drop the message from cache for retrying later
+		messagebus.DropCache(*item)
 		return err
 	}
 
 	_, err = socket.Send(item.Command, zmq.SNDMORE|zmq.DONTWAIT)
 	if nil != err {
+		// Drop the message from cache for retrying later
+		messagebus.DropCache(*item)
 		return err
 	}
 
@@ -139,6 +143,8 @@ func (brdc *broadcaster) process(socket *zmq.Socket, item *messagebus.Message) e
 			_, err = socket.SendBytes(p, zmq.SNDMORE|zmq.DONTWAIT)
 		}
 		if nil != err {
+			// Drop the message from cache for retrying later
+			messagebus.DropCache(*item)
 			return err
 		}
 	}

--- a/publish/broadcaster.go
+++ b/publish/broadcaster.go
@@ -125,14 +125,14 @@ func (brdc *broadcaster) process(socket *zmq.Socket, item *messagebus.Message) e
 	_, err := socket.Send(brdc.chain, zmq.SNDMORE|zmq.DONTWAIT)
 	if nil != err {
 		// Drop the message from cache for retrying later
-		messagebus.DropCache(*item)
+		messagebus.Bus.Broadcast.DropCache(*item)
 		return err
 	}
 
 	_, err = socket.Send(item.Command, zmq.SNDMORE|zmq.DONTWAIT)
 	if nil != err {
 		// Drop the message from cache for retrying later
-		messagebus.DropCache(*item)
+		messagebus.Bus.Broadcast.DropCache(*item)
 		return err
 	}
 
@@ -145,7 +145,7 @@ func (brdc *broadcaster) process(socket *zmq.Socket, item *messagebus.Message) e
 		}
 		if nil != err {
 			// Drop the message from cache for retrying later
-			messagebus.DropCache(*item)
+			messagebus.Bus.Broadcast.DropCache(*item)
 			return err
 		}
 	}

--- a/publish/broadcaster.go
+++ b/publish/broadcaster.go
@@ -62,7 +62,8 @@ func (brdc *broadcaster) Run(args interface{}, shutdown <-chan struct{}) {
 
 	log.Info("starting…")
 
-	queue := messagebus.Bus.Broadcast.Chan(50)
+	// use default queue size
+	queue := messagebus.Bus.Broadcast.Chan(-1)
 
 loop:
 	for {


### PR DESCRIPTION
This PR do the following
- [x] Drop the duplicate `Message` unless `rpc/peer` type to mitigate the queue is overflow.
- [x] Increase queue size for mitigate overflow
- [x] Keep block message is as highest priority when the queue is overflow by dropping lower priority ones. 