### PR TITLE
[bitmarkd] Mitigate connection loss in upstream 

### DIFF
--- a/peer/upstream/setup.go
+++ b/peer/upstream/setup.go
@@ -397,8 +397,11 @@ func push(client *zmqutil.Client, log *logger.L, item *messagebus.Message) error
 func (u *Upstream) startPolling(stopPollingSig <-chan struct{}) {
 	u.log.Debug("start polling…")
 
-	poller := zmq.NewPoller()
 	m := u.client.GetMonitorSocket()
+	if nil == m {
+		return
+	}
+	poller := zmq.NewPoller()
 	poller.Add(m, zmq.POLLIN)
 
 loop:

--- a/util/canonical.go
+++ b/util/canonical.go
@@ -76,6 +76,31 @@ func ConnectionFromIPandPort(ip net.IP, port uint16) *Connection {
 	}
 }
 
+// ConnectionFromCanonical - convert a cononical strin to a connection
+//
+// return the connection if string is canonical, otherwise nil
+func ConnectionFromCanonical(s string) *Connection {
+	if "" == s {
+		return nil
+	}
+
+	i := strings.LastIndex(s, ":")
+	if -1 == i {
+		return nil
+	}
+
+	ip := net.ParseIP(s[0 : i-1])
+	port, err := strconv.ParseInt(s[i+1:len(s)], 10, 16)
+	if nil == ip || nil != err {
+		return nil
+	}
+
+	return &Connection{
+		ip:   ip,
+		port: uint16(port),
+	}
+}
+
 // CanonicalIPandPort - make the IP:Port into canonical string
 //
 // examples:


### PR DESCRIPTION
This PR do the following
- [x] Add the socket monitor for the upstream socket to detect disconnection signal and try to reconnect again. 
- [x] Avoid trying to do some redundant connections. 

Change:
- I also delete the `poller` in `zmqutil/client.go`. The reason is to avoid concurrent polling and sending/receiving from same socket.