### PR TITLE
[bitmarkd] support generating proof identity v2 seed as default

### DIFF
--- a/account/private.go
+++ b/account/private.go
@@ -7,6 +7,8 @@ package account
 
 import (
 	"bytes"
+	"crypto/rand"
+	"fmt"
 
 	"golang.org/x/crypto/ed25519"
 	"golang.org/x/crypto/nacl/secretbox"
@@ -47,8 +49,8 @@ type NothingPrivateKey struct {
 // seed parameters
 var (
 	seedHeader   = []byte{0x5a, 0xfe}
-	SeedHeaderV1 = append(seedHeader, []byte{0x01}...)
-	SeedHeaderV2 = append(seedHeader, []byte{0x02}...)
+	seedHeaderV1 = append(seedHeader, []byte{0x01}...)
+	seedHeaderV2 = append(seedHeader, []byte{0x02}...)
 )
 
 // for seed v1 only
@@ -67,12 +69,12 @@ var (
 const (
 	seedHeaderLength   = 3
 	seedPrefixLength   = 1
-	SecretKeyV1Length  = 32
-	SecretKeyV2Length  = 17
-	SeedChecksumLength = 4
+	secretKeyV1Length  = 32
+	secretKeyV2Length  = 17
+	seedChecksumLength = 4
 
-	SeedV1Length = 40
-	SeedV2Length = 24
+	seedV1Length = 40
+	seedV2Length = 24
 )
 
 // PrivateKeyFromBase58Seed - this converts a Base58 encoded seed string and returns a private key
@@ -84,27 +86,27 @@ func PrivateKeyFromBase58Seed(seedBase58Encoded string) (*PrivateKey, error) {
 	// verify length
 	seed := util.FromBase58(seedBase58Encoded)
 	seedLength := len(seed)
-	if SeedV1Length != seedLength && SeedV2Length != seedLength {
+	if seedV1Length != seedLength && seedV2Length != seedLength {
 		return nil, fault.ErrInvalidSeedLength
 	}
 
 	// verify checksum
 	digest := sha3.Sum256(seed[:seedLength-checksumLength])
-	checksumStart := seedLength - SeedChecksumLength
-	expectedChecksum := digest[:SeedChecksumLength]
+	checksumStart := seedLength - seedChecksumLength
+	expectedChecksum := digest[:seedChecksumLength]
 	actualChecksum := seed[checksumStart:]
 	if !bytes.Equal(expectedChecksum, actualChecksum) {
 		return nil, fault.ErrChecksumMismatch
 	}
 
 	header := seed[:seedHeaderLength]
-	var encryptedSk []byte // encrypted secret key for generate key pair
+	var ed25519Seed []byte // the ed25519 seed for generate key pair
 	var testnet bool       // denote the network is test net
 
 	switch {
-	case bytes.Equal(SeedHeaderV1, header):
+	case bytes.Equal(seedHeaderV1, header):
 		// copy the secret key from seed
-		var sk [SecretKeyV1Length]byte
+		var sk [secretKeyV1Length]byte
 		secretStart := seedHeaderLength + seedPrefixLength
 		copy(sk[:], seed[secretStart:])
 
@@ -112,13 +114,13 @@ func PrivateKeyFromBase58Seed(seedBase58Encoded string) (*PrivateKey, error) {
 		// first byte of prefix is test/live indication
 		testnet = prefix[0] == 0x01
 
-		encryptedSk = secretbox.Seal([]byte{}, authSeedIndex[:], &seedNonce, &sk)
+		ed25519Seed = secretbox.Seal([]byte{}, authSeedIndex[:], &seedNonce, &sk)
 
-	case bytes.Equal(SeedHeaderV2, header):
+	case bytes.Equal(seedHeaderV2, header):
 		sk := seed[seedHeaderLength:checksumStart]
 
 		// verify valid secret key
-		if SecretKeyV2Length != len(sk) || 0 != sk[16]&0x0f {
+		if secretKeyV2Length != len(sk) || 0 != sk[16]&0x0f {
 			return nil, fault.ErrInvalidSeedLength
 		}
 
@@ -133,18 +135,17 @@ func PrivateKeyFromBase58Seed(seedBase58Encoded string) (*PrivateKey, error) {
 			if err != nil {
 				return nil, err
 			}
-			if SecretKeyV2Length != n {
+			if secretKeyV2Length != n {
 				return nil, fault.ErrCannotDecodeSeed
 			}
 		}
 
-		const encryptedSkLength = 32
-		encryptedSk = make([]byte, encryptedSkLength)
-		n, err := hash.Read(encryptedSk)
+		ed25519Seed = make([]byte, ed25519.SeedSize)
+		n, err := hash.Read(ed25519Seed)
 		if nil != err {
 			return nil, err
 		}
-		if encryptedSkLength != n {
+		if ed25519.SeedSize != n {
 			return nil, fault.ErrCannotDecodeSeed
 		}
 
@@ -153,7 +154,7 @@ func PrivateKeyFromBase58Seed(seedBase58Encoded string) (*PrivateKey, error) {
 	}
 
 	// generate key pair from encrypted secret key
-	_, priv, err := ed25519.GenerateKey(bytes.NewBuffer(encryptedSk))
+	_, priv, err := ed25519.GenerateKey(bytes.NewBuffer(ed25519Seed))
 	if nil != err {
 		return nil, err
 	}
@@ -402,4 +403,43 @@ func (privateKey *NothingPrivateKey) String() string {
 // MarshalText - convert an privateKey to its Base58 JSON form
 func (privateKey NothingPrivateKey) MarshalText() ([]byte, error) {
 	return []byte(privateKey.String()), nil
+}
+
+// GenerateEncodedSeedV2 generate base58 seed v2
+func GenerateEncodedSeedV2(testnet bool) (string, error) {
+
+	// space for 128 bit, extend to 132 bit later
+	sk := make([]byte, 16, secretKeyV2Length)
+
+	n, err := rand.Read(sk)
+	if nil != err {
+		return "", err
+	}
+
+	if 16 != n {
+		return "", fmt.Errorf("got %d bytes, expected is 16 bytes", n)
+	}
+
+	// extend to 132 bits
+	sk = append(sk, sk[15]&0xf0)
+
+	if secretKeyV2Length != len(sk) {
+		return "", fmt.Errorf("actual seed length is %d bytes, expected is %d bytes", len(sk), secretKeyV2Length)
+	}
+
+	// network flag
+	mode := sk[0]&0x80 | sk[1]&0x40 | sk[2]&0x20 | sk[3]&0x10
+	if testnet {
+		mode = mode ^ 0xf0
+	}
+	sk[15] = mode | sk[15]&0x0f
+
+	// encode seed to base58
+	seed := make([]byte, 0)
+	seed = append(seed, seedHeaderV2...)
+	seed = append(seed, sk...)
+	digest := sha3.Sum256(seed)
+	checksum := digest[:seedChecksumLength]
+	seed = append(seed, checksum...)
+	return util.ToBase58(seed), nil
 }

--- a/command/bitmarkd/commands.go
+++ b/command/bitmarkd/commands.go
@@ -19,6 +19,7 @@ import (
 
 	"golang.org/x/crypto/sha3"
 
+	"github.com/bitmark-inc/bitmarkd/account"
 	"github.com/bitmark-inc/bitmarkd/block"
 	"github.com/bitmark-inc/bitmarkd/blockheader"
 	"github.com/bitmark-inc/bitmarkd/fault"
@@ -58,8 +59,7 @@ func processSetupCommand(arguments []string) bool {
 		privateKeyFilename := getFilenameWithDirectory(arguments, peerPrivateKeyFilename)
 		err := zmqutil.MakeKeyPair(publicKeyFilename, privateKeyFilename)
 		if nil != err {
-			fmt.Printf("cannot generate private key: %q and public key: %q\n", privateKeyFilename, publicKeyFilename)
-			fmt.Printf("error generating server key pair: %s\n", err)
+			fmt.Printf("generate private key: %q and public key: %q error: %s\n", privateKeyFilename, publicKeyFilename, err)
 			exitwithstatus.Exit(1)
 		}
 		fmt.Printf("generated private key: %q and public key: %q\n", privateKeyFilename, publicKeyFilename)
@@ -67,6 +67,7 @@ func processSetupCommand(arguments []string) bool {
 	case "gen-rpc-cert", "rpc":
 		certificateFilename := getFilenameWithDirectory(arguments, rpcCertificateKeyFilename)
 		privateKeyFilename := getFilenameWithDirectory(arguments, rpcPrivateKeyFilename)
+
 		addresses := []string{}
 		if len(arguments) >= 2 {
 			for _, a := range arguments[1:] {
@@ -75,10 +76,10 @@ func processSetupCommand(arguments []string) bool {
 				}
 			}
 		}
+
 		err := makeSelfSignedCertificate("rpc", certificateFilename, privateKeyFilename, 0 != len(addresses), addresses)
 		if nil != err {
-			fmt.Printf("cannot generate RPC key: %q and certificate: %q\n", privateKeyFilename, certificateFilename)
-			fmt.Printf("error generating RPC key/certificate: %s\n", err)
+			fmt.Printf("generate RPC key: %q and certificate: %q error: %s\n", privateKeyFilename, certificateFilename, err)
 			exitwithstatus.Exit(1)
 		}
 		fmt.Printf("generated RPC key: %q and certificate: %q\n", privateKeyFilename, certificateFilename)
@@ -86,28 +87,32 @@ func processSetupCommand(arguments []string) bool {
 	case "gen-proof-identity", "proof":
 		publicKeyFilename := getFilenameWithDirectory(arguments, proofPublicKeyFilename)
 		privateKeyFilename := getFilenameWithDirectory(arguments, proofPrivateKeyFilename)
-		liveSigningKeyFilename := getFilenameWithDirectory(arguments, proofLiveSigningKeyFilename)
-		testSigningKeyFilename := getFilenameWithDirectory(arguments, proofTestSigningKeyFilename)
 		err := zmqutil.MakeKeyPair(publicKeyFilename, privateKeyFilename)
 		if nil != err {
-			fmt.Printf("cannot generate private key: %q and public key: %q\n", privateKeyFilename, publicKeyFilename)
-			fmt.Printf("error generating server key pair: %s\n", err)
+			fmt.Printf("generate private key: %q and public key: %q error: %s\n", privateKeyFilename, publicKeyFilename, err)
 			exitwithstatus.Exit(1)
 		}
 
-		if err := makeSigningKey(false, liveSigningKeyFilename); err != nil {
-			fmt.Printf("cannot generate the signing key for livenet: %q\n", liveSigningKeyFilename)
-			fmt.Printf("error generatingthe signing key for livenet: %s\n", err)
-			exitwithstatus.Exit(1)
+		liveSigningKeyFilename := getFilenameWithDirectory(arguments, proofLiveSigningKeyFilename)
+		testSigningKeyFilename := getFilenameWithDirectory(arguments, proofTestSigningKeyFilename)
+
+		if err := makeSigningKey(false, liveSigningKeyFilename); nil != err {
+			fmt.Printf("generate the signing key for livenet: %q error: %s\n", liveSigningKeyFilename, err)
+			goto singing_key_failed
 		}
-		if err := makeSigningKey(true, testSigningKeyFilename); err != nil {
-			fmt.Printf("cannot generate the signing key for testnet: %q\n", testSigningKeyFilename)
-			fmt.Printf("error generatingthe signing key for testnet: %s\n", err)
-			exitwithstatus.Exit(1)
+		if err := makeSigningKey(true, testSigningKeyFilename); nil != err {
+			fmt.Printf(" generate the signing key for testnet: %q error: %s\n", testSigningKeyFilename, err)
+			goto singing_key_failed
 		}
 
 		fmt.Printf("generated private key: %q and public key: %q\n", privateKeyFilename, publicKeyFilename)
 		fmt.Printf("generated signing keys: %q and %q\n", liveSigningKeyFilename, testSigningKeyFilename)
+		goto done
+
+	singing_key_failed:
+		_ = os.Remove(publicKeyFilename)
+		_ = os.Remove(privateKeyFilename)
+		exitwithstatus.Exit(1)
 
 	case "dns-txt", "txt":
 		return false // defer processing until configuration is read
@@ -173,6 +178,7 @@ func processSetupCommand(arguments []string) bool {
 		exitwithstatus.Exit(1)
 	}
 
+done:
 	// indicate processing complete and prefor normal exit from main
 	return true
 }
@@ -455,23 +461,54 @@ func getFilenameWithDirectory(arguments []string, name string) string {
 	return filepath.Join(dir, name)
 }
 
-func makeSigningKey(test bool, fileName string) error {
-	seedCore := make([]byte, 32)
-	if _, err := rand.Read(seedCore); err != nil {
-		return fmt.Errorf("failed to generate signing core error: %s", err)
+func makeSigningKey(testnet bool, fileName string) error {
+	seed, err := generateEncodedSeed(testnet)
+	if nil != err {
+		return err
 	}
-	seed := []byte{0x5a, 0xfe, 0x01, 0x00} // header + network(live)
-	if test {
-		seed[3] = 0x01 // change network to testing
-	}
-	seed = append(seed, seedCore...)
-	checksum := sha3.Sum256(seed)
-	seed = append(seed, checksum[:4]...)
 
-	data := "SEED:" + util.ToBase58(seed) + "\n"
-	if err := ioutil.WriteFile(fileName, []byte(data), 0600); err != nil {
+	data := "SEED:" + seed + "\n"
+	if err = ioutil.WriteFile(fileName, []byte(data), 0600); nil != err {
 		return fmt.Errorf("error writing signing key file error: %s", err)
 	}
 
 	return nil
+}
+
+func generateEncodedSeed(testnet bool) (string, error) {
+
+	// space for 128 bit, extend to 132 bit later
+	sk := make([]byte, 16, account.SecretKeyV2Length)
+
+	n, err := rand.Read(sk)
+	if nil != err {
+		return "", err
+	}
+
+	if 16 != n {
+		return "", fmt.Errorf("got %d bytes, expected is 16 bytes", n)
+	}
+
+	// extend to 132 bits
+	sk = append(sk, sk[15]&0xf0)
+
+	if account.SecretKeyV2Length != len(sk) {
+		return "", fmt.Errorf("actual seed length is %d bytes, expected is %d bytes", len(sk), account.SecretKeyV2Length)
+	}
+
+	// network flag
+	mode := sk[0]&0x80 | sk[1]&0x40 | sk[2]&0x20 | sk[3]&0x10
+	if testnet {
+		mode = mode ^ 0xf0
+	}
+	sk[15] = mode | sk[15]&0x0f
+
+	// encode seed to base58
+	seed := make([]byte, 0)
+	seed = append(seed, account.SeedHeaderV2...)
+	seed = append(seed, sk...)
+	digest := sha3.Sum256(seed)
+	checksum := digest[:account.SeedChecksumLength]
+	seed = append(seed, checksum...)
+	return util.ToBase58(seed), nil
 }


### PR DESCRIPTION
This PR does the following:
- [x] Support generating v2 seed as default identity for proof.
