### PR TITLE
Fix block not sync

### DIFF
--- a/block/store.go
+++ b/block/store.go
@@ -7,7 +7,6 @@ package block
 
 import (
 	"encoding/binary"
-	"fmt"
 	"time"
 
 	"github.com/bitmark-inc/bitmarkd/account"
@@ -359,7 +358,6 @@ func StoreIncoming(packedBlock []byte, performRescan rescanType) (err error) {
 
 	trx, err := storage.NewDBTransaction()
 	if nil != err {
-		fmt.Printf("aaron create transaction error\n")
 		return err
 	}
 
@@ -648,7 +646,6 @@ func StoreIncoming(packedBlock []byte, performRescan rescanType) (err error) {
 
 	err = trx.Commit()
 	if nil != err {
-		fmt.Printf("Aaron commit error: %v\n", err)
 		return err
 	}
 

--- a/blockrecord/header.go
+++ b/blockrecord/header.go
@@ -222,6 +222,10 @@ func FoundationTxId(header *Header, digest blockdigest.Digest) merkle.Digest {
 // AdjustDifficultyAtBlock - adjust difficulty at block, returns next difficulty, current difficulty, error
 func AdjustDifficultyAtBlock(height uint64) (float64, float64, error) {
 	currentDifficulty := difficulty.Current.Value()
+	if MinimumBlockNumber >= height {
+		return currentDifficulty, currentDifficulty, nil
+	}
+
 	nextDifficulty, err := DifficultyByPreviousTimespanAtBlock(height)
 	if err != nil {
 		log.Errorf("get difficulty value with error: %s", err)

--- a/blockrecord/header.go
+++ b/blockrecord/header.go
@@ -108,9 +108,12 @@ func ExtractHeader(block []byte, checkHeight uint64) (*Header, blockdigest.Diges
 		return nil, blockdigest.Digest{}, nil, err
 	}
 
-	if checkHeight > genesis.BlockNumber && header.Number != checkHeight {
-		log.Errorf("check height %d, incoming block height %d, error: %s", checkHeight, header.Number, fault.ErrHeightOutOfSequence)
-		return nil, blockdigest.Digest{}, nil, fault.ErrHeightOutOfSequence
+	if checkHeight > genesis.BlockNumber {
+		err := validNextHeightFromExpected(checkHeight, header.Number)
+		if nil != err {
+			log.Errorf("check height %d, incoming block height %d, error: %s", checkHeight, header.Number, err)
+			return nil, blockdigest.Digest{}, nil, err
+		}
 	}
 
 	var digest blockdigest.Digest

--- a/blockrecord/header.go
+++ b/blockrecord/header.go
@@ -220,6 +220,7 @@ func FoundationTxId(header *Header, digest blockdigest.Digest) merkle.Digest {
 }
 
 // AdjustDifficultyAtBlock - adjust difficulty at block, returns next difficulty, current difficulty, error
+// make sure header version is correct before calling this function
 func AdjustDifficultyAtBlock(height uint64) (float64, float64, error) {
 	currentDifficulty := difficulty.Current.Value()
 	if MinimumBlockNumber >= height {

--- a/blockrecord/validator.go
+++ b/blockrecord/validator.go
@@ -68,3 +68,13 @@ func ValidBlockLinkage(currentDigest blockdigest.Digest, incomingDigestOfPreviou
 
 	return nil
 }
+
+// most time next height is increased by 1 from current height,
+// but it is also valid when incoming block is same height with smaller digest
+func validNextHeightFromExpected(expectedNextHeight uint64, nextHeight uint64) error {
+	if nextHeight < expectedNextHeight-1 || nextHeight > expectedNextHeight {
+		return fault.ErrHeightOutOfSequence
+	}
+
+	return nil
+}

--- a/command/bitmarkd/main.go
+++ b/command/bitmarkd/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/bitmark-inc/bitmarkd/blockheader"
 	"github.com/bitmark-inc/bitmarkd/blockrecord"
 	"github.com/bitmark-inc/bitmarkd/chain"
+	"github.com/bitmark-inc/bitmarkd/difficulty"
 	"github.com/bitmark-inc/bitmarkd/mode"
 	"github.com/bitmark-inc/bitmarkd/payment"
 	"github.com/bitmark-inc/bitmarkd/peer"
@@ -218,8 +219,8 @@ func main() {
 	}
 
 	// adjust difficulty to fit current status
-	_, _, blockHeaderVersion, _ := blockheader.Get()
-	if blockrecord.IsDifficultyAppliedVersion(blockHeaderVersion) {
+	height, _, blockHeaderVersion, _ := blockheader.Get()
+	if blockrecord.IsDifficultyAppliedVersion(blockHeaderVersion) && difficulty.AdjustTimespanInBlocks < height {
 		log.Info("initialise difficulty based on existing blocks")
 		_, _, err = blockrecord.AdjustDifficultyAtBlock(blockheader.Height())
 		if nil != err {

--- a/command/bitmarkd/main.go
+++ b/command/bitmarkd/main.go
@@ -217,6 +217,17 @@ func main() {
 		return
 	}
 
+	// adjust difficulty to fit current status
+	_, _, blockHeaderVersion, _ := blockheader.Get()
+	if blockrecord.IsDifficultyAppliedVersion(blockHeaderVersion) {
+		log.Info("initialise difficulty based on existing blocks")
+		_, _, err = blockrecord.AdjustDifficultyAtBlock(blockheader.Height())
+		if nil != err {
+			log.Criticalf("initialise difficulty error: %s", err)
+			exitwithstatus.Message("initialise difficulty error: %s", err)
+		}
+	}
+
 	// reservoir and block are both ready
 	// so can restore any previously saved transactions
 	// before any peer services are started

--- a/storage/handle.go
+++ b/storage/handle.go
@@ -14,7 +14,6 @@ import (
 	"github.com/bitmark-inc/logger"
 )
 
-// TODO: Aaron use interface of Handle
 type Handle interface {
 	Begin()
 	Commit() error

--- a/zmqutil/client.go
+++ b/zmqutil/client.go
@@ -22,23 +22,17 @@ import (
 )
 
 type ClientIntf interface {
+	Close() error
 	Connect(conn *util.Connection, serverPublicKey []byte, prefix string) error
+	ConnectedTo() *Connected
+	GoString() string
 	IsConnected() bool
 	IsConnectedTo(serverPublicKey []byte) bool
 	Reconnect() error
-	ReconnectReturningSocket() (*zmq.Socket, error)
-	ReconnectOpenedSocket() error
-	GetSocket() *zmq.Socket
-	Close() error
-	Send(items ...interface{}) error
 	Receive(flags zmq.Flag) ([][]byte, error)
-	BeginPolling(poller *Poller, events zmq.State) *zmq.Socket
-	String() string
-	ConnectedTo() *Connected
-	GoString() string
-	GetMonitorSocket() *zmq.Socket
+	Send(items ...interface{}) error
 	ServerPublicKey() []byte
-	ResetServer() error
+	String() string
 }
 
 // Client - structure to hold a client connection


### PR DESCRIPTION
Fix bitmarkd not able to sync when a bitmarkd just start and difficulty is not reset.

Also fix a performance problem that if a block with same height but with smaller digest, it comes in will be rejected. Previously every block is assumes to be higher than local one, as consensus is modified, same height block could still comes.