### PR TITLE
Fix incoming block not apply difficulty

### DIFF
--- a/block/delete.go
+++ b/block/delete.go
@@ -53,17 +53,19 @@ outer_loop:
 			blockheader.Set(header.Number, digest, header.Version, header.Timestamp)
 			log.Infof("finish: _NOT_ Deleting: %d", header.Number)
 
-			if header.Number >= difficulty.AdjustTimespanInBlocks {
-				nextDifficulty, prevDifficulty, err := blockrecord.AdjustDifficultyAtBlock(header.Number)
-				if err != nil {
-					log.Errorf("failed to adjust difficulty with error: %s", err)
-					return err
+			if blockrecord.IsDifficultyAppliedVersion(header.Version) {
+				if header.Number >= difficulty.AdjustTimespanInBlocks {
+					nextDifficulty, prevDifficulty, err := blockrecord.AdjustDifficultyAtBlock(header.Number)
+					if err != nil {
+						log.Errorf("failed to adjust difficulty with error: %s", err)
+						return err
+					}
+					log.Infof("set new difficulty to %f, previous difficulty %f", nextDifficulty, prevDifficulty)
+				} else {
+					// in case fork happens around first difficulty adjust, difficulty might be changed and
+					// delete down blocks below adjustment block, leave difficulty different than other nodes
+					blockrecord.ResetDifficulty()
 				}
-				log.Infof("set new difficulty to %f, previous difficulty %f", nextDifficulty, prevDifficulty)
-			} else {
-				// in case fork happens around first difficulty adjust, difficulty might be changed and
-				// delete down blocks below adjustment block, leave difficulty different than other nodes
-				blockrecord.ResetDifficulty()
 			}
 			return nil
 		}

--- a/block/store.go
+++ b/block/store.go
@@ -56,25 +56,32 @@ func StoreIncoming(packedBlock []byte, performRescan rescanType) (err error) {
 		return err
 	}
 
-	if blockrecord.IsDifficultyAppliedVersion(header.Version) && difficulty.IsAdjustBlock(header.Number) {
-		nextDifficulty, prevDifficulty, err := blockrecord.AdjustDifficultyAtBlock(header.Number)
-		// if any error happens for storing block, reset difficulty back to old value
-		defer func(prevDifficulty float64) {
-			if err != nil {
-				difficulty.Current.Set(prevDifficulty)
-			}
-		}(prevDifficulty)
-
-		if err != nil {
-			globalData.log.Errorf("adjust difficulty with error: %s", err)
-			return err
-		}
-		globalData.log.Infof("previous difficulty: %f, current difficulty: %f", prevDifficulty, nextDifficulty)
+	// incoming version should always be larger or equal to current
+	if err := blockrecord.ValidHeaderVersion(previousVersion, header.Version); err != nil {
+		return err
 	}
 
-	if err := blockrecord.ValidIncomingDifficuty(header.Difficulty); err != nil {
-		globalData.log.Errorf("incoming block difficulty %f different from local %f", header.Difficulty.Value(), difficulty.Current.Value())
-		return err
+	if blockrecord.IsDifficultyAppliedVersion(header.Version) {
+		if difficulty.IsAdjustBlock(header.Number) {
+			nextDifficulty, prevDifficulty, err := blockrecord.AdjustDifficultyAtBlock(header.Number)
+			// if any error happens for storing block, reset difficulty back to old value
+			defer func(prevDifficulty float64) {
+				if err != nil {
+					difficulty.Current.Set(prevDifficulty)
+				}
+			}(prevDifficulty)
+
+			if err != nil {
+				globalData.log.Errorf("adjust difficulty with error: %s", err)
+				return err
+			}
+			globalData.log.Infof("previous difficulty: %f, current difficulty: %f", prevDifficulty, nextDifficulty)
+		}
+
+		if err := blockrecord.ValidIncomingDifficuty(header.Difficulty); err != nil {
+			globalData.log.Errorf("incoming block difficulty %f different from local %f", header.Difficulty.Value(), difficulty.Current.Value())
+			return err
+		}
 	}
 
 	if ok := digest.IsValidByDifficulty(header.Difficulty); !ok {
@@ -84,11 +91,6 @@ func StoreIncoming(packedBlock []byte, performRescan rescanType) (err error) {
 
 	// ensure correct linkage
 	if err := blockrecord.ValidBlockLinkage(previousBlock, header.PreviousBlock); err != nil {
-		return err
-	}
-
-	// check version
-	if err := blockrecord.ValidHeaderVersion(previousVersion, header.Version); err != nil {
 		return err
 	}
 

--- a/blockrecord/header.go
+++ b/blockrecord/header.go
@@ -266,7 +266,7 @@ func DifficultyByPreviousTimespanAtBlock(height uint64) (float64, error) {
 
 func prevDifficultyBaseAtBlock(height uint64) (float64, error) {
 	var baseBlockHeight uint64
-	if difficulty.IsAdjustBlock(height) {
+	if isDifficultyAdjustBlock(height) {
 		baseBlockHeight = height - 1
 	} else {
 		baseBlockHeight = height - difficulty.AdjustTimespanInBlocks

--- a/blockrecord/header.go
+++ b/blockrecord/header.go
@@ -266,7 +266,7 @@ func DifficultyByPreviousTimespanAtBlock(height uint64) (float64, error) {
 
 func prevDifficultyBaseAtBlock(height uint64) (float64, error) {
 	var baseBlockHeight uint64
-	if isDifficultyAdjustBlock(height) {
+	if isDifficultyAdjustmentBlock(height) {
 		baseBlockHeight = height - 1
 	} else {
 		baseBlockHeight = height - difficulty.AdjustTimespanInBlocks

--- a/blockrecord/validator.go
+++ b/blockrecord/validator.go
@@ -34,8 +34,12 @@ func ValidBlockTimeSpacingAtVersion(version uint16, timeSpacing uint64) error {
 }
 
 // ValidIncomingDifficuty - valid incoming difficulty
-func ValidIncomingDifficuty(incoming *difficulty.Difficulty) error {
-	if incoming.Value() != difficulty.Current.Value() {
+func ValidIncomingDifficuty(header *Header) error {
+	if !IsDifficultyAppliedVersion(header.Version) {
+		return nil
+	}
+
+	if header.Difficulty.Value() != difficulty.Current.Value() {
 		return fault.ErrDifficultyNotMatch
 	}
 	return nil
@@ -44,6 +48,18 @@ func ValidIncomingDifficuty(incoming *difficulty.Difficulty) error {
 // IsDifficultyAppliedVersion - is difficulty rule applied at header version
 func IsDifficultyAppliedVersion(version uint16) bool {
 	return version >= difficultyAppliedVersion
+}
+
+// IsBlockToAdjustDifficulty - is block the one to adjust difficulty
+func IsBlockToAdjustDifficulty(height uint64, version uint16) bool {
+	if !IsDifficultyAppliedVersion(version) {
+		return false
+	}
+	return isDifficultyAdjustmentBlock(height)
+}
+
+func isDifficultyAdjustmentBlock(height uint64) bool {
+	return 0 == height%difficulty.AdjustTimespanInBlocks
 }
 
 // ValidHeaderVersion - valid incoming block version

--- a/difficulty/difficulty.go
+++ b/difficulty/difficulty.go
@@ -320,11 +320,6 @@ func adjustRatioByLastTimespan(actualTimespanSecond uint64) float64 {
 	return float64(adjustTimespanInSecond) / float64(actualTimespanSecond)
 }
 
-// IsAdjustBlock - is block the one to adjust difficulty
-func IsAdjustBlock(height uint64) bool {
-	return height%AdjustTimespanInBlocks == 0
-}
-
 // PrevTimespanBlockBeginAndEnd - previous begin & end block of difficulty timespan
 func PrevTimespanBlockBeginAndEnd(height uint64) (uint64, uint64) {
 	if remainder := height % AdjustTimespanInBlocks; remainder != 0 {

--- a/difficulty/difficulty_test.go
+++ b/difficulty/difficulty_test.go
@@ -243,18 +243,6 @@ func TestReciprocal(t *testing.T) {
 	}
 }
 
-func TestIsAdjustBlockWhenStrtInterval(t *testing.T) {
-	height := uint64(difficulty.AdjustTimespanInBlocks * 200000)
-	ok := difficulty.IsAdjustBlock(height)
-	assert.Equal(t, true, ok, "starting of difficulty timespan")
-}
-
-func TestIsAdjustBlockWhenMiddleInterval(t *testing.T) {
-	height := uint64(difficulty.AdjustTimespanInBlocks*200000 + 1)
-	ok := difficulty.IsAdjustBlock(height)
-	assert.Equal(t, false, ok, "middle of difficulty timespan")
-}
-
 func TestPrevTimespanBlockBeginAndEndWhenAtMiddle(t *testing.T) {
 	height := uint64(difficulty.AdjustTimespanInBlocks*3 + 10)
 	begin, end := difficulty.PrevTimespanBlockBeginAndEnd(height)

--- a/proof/publisher.go
+++ b/proof/publisher.go
@@ -296,7 +296,7 @@ func (pub *publisher) process() {
 	message.Header.PreviousBlock, message.Header.Number = blockheader.GetNew()
 
 	pub.log.Debugf("current difficulty: %f", message.Header.Difficulty.Value())
-	if difficulty.IsAdjustBlock(message.Header.Number) {
+	if blockrecord.IsBlockToAdjustDifficulty(message.Header.Number, message.Header.Version) {
 		newDifficulty, _ := blockrecord.DifficultyByPreviousTimespanAtBlock(message.Header.Number)
 
 		diff := difficulty.New()


### PR DESCRIPTION
Incoming block difficulty should be check and apply only when other nodes considering difficulty.

The bug happens that some functions are coupled together (need to check header version before checking difficulty). To avoid unexpectedly missing function call, this modification moves difficulty header checking into difficulty validation functions.