### PR TITLE
Import peer not expired

### DIFF
--- a/announce/nodeslookup.go
+++ b/announce/nodeslookup.go
@@ -177,7 +177,7 @@ func lookupNodesDomain(domain string, log *logger.L) error {
 				log.Infof("result[%d]: adding: %x", i, listeners)
 
 				// internal add, as lock is already held
-				addPeer(tag.publicKey, listeners, 0)
+				addPeer(tag.publicKey, listeners, uint64(time.Now().Unix()))
 			}
 		}
 	}

--- a/announce/peer.go
+++ b/announce/peer.go
@@ -55,6 +55,11 @@ func SetPeer(publicKey []byte, listeners []byte) error {
 	return nil
 }
 
+// IsPeerExpiredFromTime - is peer expired from time
+func IsPeerExpiredFromTime(timestamp uint64) bool {
+	return time.Unix(int64(timestamp), 0).Add(announceExpiry).Before(time.Now())
+}
+
 // AddPeer - add a peer announcement to the in-memory tree
 // returns:
 //   true  if this was a new/updated entry

--- a/announce/peer.go
+++ b/announce/peer.go
@@ -46,7 +46,7 @@ func SetPeer(publicKey []byte, listeners []byte) error {
 	globalData.listeners = listeners
 	globalData.peerSet = true
 
-	addPeer(publicKey, listeners, 0)
+	addPeer(publicKey, listeners, uint64(time.Now().Unix()))
 
 	globalData.thisNode, _ = globalData.peerTree.Search(pubkey(publicKey))
 
@@ -55,9 +55,9 @@ func SetPeer(publicKey []byte, listeners []byte) error {
 	return nil
 }
 
-// IsPeerExpiredFromTime - is peer expired from time
-func IsPeerExpiredFromTime(timestamp uint64) bool {
-	return time.Unix(int64(timestamp), 0).Add(announceExpiry).Before(time.Now())
+// isPeerExpiredFromTime - is peer expired from time
+func isPeerExpiredFromTime(timestamp time.Time) bool {
+	return timestamp.Add(announceExpiry).Before(time.Now())
 }
 
 // AddPeer - add a peer announcement to the in-memory tree
@@ -73,15 +73,8 @@ func AddPeer(publicKey []byte, listeners []byte, timestamp uint64) bool {
 
 // internal add a peer announcement, hold lock before calling
 func addPeer(publicKey []byte, listeners []byte, timestamp uint64) bool {
-
-	// disallow future timestamps: require timestamp ≤ Now
-	ts := time.Now()
-	if timestamp != 0 && timestamp <= uint64(ts.Unix()) {
-		ts = time.Unix(int64(timestamp), 0)
-	}
-
-	// ignore expired request
-	if time.Since(ts) >= announceExpiry {
+	ts := resetFutureTimestampToNow(timestamp)
+	if isPeerExpiredFromTime(ts) {
 		return false
 	}
 
@@ -114,6 +107,16 @@ func addPeer(publicKey []byte, listeners []byte, timestamp uint64) bool {
 	}
 
 	return true
+}
+
+// resetFutureTimestampToNow - reset future timestamp to now
+func resetFutureTimestampToNow(timestamp uint64) time.Time {
+	ts := time.Unix(int64(timestamp), 0)
+	now := time.Now()
+	if now.Before(ts) {
+		return now
+	}
+	return ts
 }
 
 // GetNext - fetch the data for the next node in the ring for a given public key

--- a/announce/peer_test.go
+++ b/announce/peer_test.go
@@ -4,27 +4,3 @@
 // license that can be found in the LICENSE file.
 
 package announce_test
-
-import (
-	"testing"
-	"time"
-
-	"github.com/bitmark-inc/bitmarkd/announce"
-	"github.com/stretchr/testify/assert"
-)
-
-const (
-	announceExpiry = 55 * time.Minute
-)
-
-func TestIsPeerExpiredFromTimeWhenExpired(t *testing.T) {
-	former := uint64(time.Now().Add(-2 * announceExpiry).Unix())
-	expired := announce.IsPeerExpiredFromTime(former)
-	assert.Equal(t, true, expired, "expired")
-}
-
-func TestIsPeerExpiredFromTimeWhenNotExpired(t *testing.T) {
-	former := uint64(time.Now().Add(-1 * announceExpiry / 2).Unix())
-	expired := announce.IsPeerExpiredFromTime(former)
-	assert.Equal(t, false, expired, "expired")
-}

--- a/announce/peer_test.go
+++ b/announce/peer_test.go
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: ISC
-// Copyright (c) 2014-2019 Bitmark Inc.
-// Use of this source code is governed by an ISC
-// license that can be found in the LICENSE file.
-
-package announce_test

--- a/announce/peer_test.go
+++ b/announce/peer_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: ISC
+// Copyright (c) 2014-2019 Bitmark Inc.
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package announce_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bitmark-inc/bitmarkd/announce"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	announceExpiry = 55 * time.Minute
+)
+
+func TestIsPeerExpiredFromTimeWhenExpired(t *testing.T) {
+	former := uint64(time.Now().Add(-2 * announceExpiry).Unix())
+	expired := announce.IsPeerExpiredFromTime(former)
+	assert.Equal(t, true, expired, "expired")
+}
+
+func TestIsPeerExpiredFromTimeWhenNotExpired(t *testing.T) {
+	former := uint64(time.Now().Add(-1 * announceExpiry / 2).Unix())
+	expired := announce.IsPeerExpiredFromTime(former)
+	assert.Equal(t, false, expired, "expired")
+}

--- a/announce/rpc.go
+++ b/announce/rpc.go
@@ -57,21 +57,12 @@ func addRPC(fingerprint fingerprintType, rpcs []byte, timestamp uint64, local bo
 
 	// if new item
 	if !ok {
-
-		ts := time.Now()
-
-		// disallow future timestamps: require timestamp ≤ Now
-		if timestamp != 0 && timestamp <= uint64(ts.Unix()) {
-			ts = time.Unix(int64(timestamp), 0)
-		}
-
-		// ignore expired request
-		if time.Since(ts) >= announceExpiry {
+		ts := resetFutureTimestampToNow(timestamp)
+		if isPeerExpiredFromTime(ts) {
 			return false
 		}
 
 		// ***** FIX THIS: add more validation here
-
 		e := &rpcEntry{
 			address:     rpcs,
 			fingerprint: fingerprint,

--- a/announce/store.go
+++ b/announce/store.go
@@ -148,9 +148,6 @@ func restorePeers(peerFile string) error {
 	}
 
 	for _, peer := range peers {
-		if IsPeerExpiredFromTime(peer.Timestamp) {
-			continue
-		}
 		addPeer(peer.PublicKey, peer.Listeners, peer.Timestamp)
 	}
 	return nil

--- a/announce/store.go
+++ b/announce/store.go
@@ -132,7 +132,7 @@ func restorePeers(peerFile string) error {
 
 	f, err := os.OpenFile(peerFile, os.O_RDONLY, 0600)
 	if err != nil {
-		// peer file not exist shoulnd't return error, for example when starting
+		// peer file not exist shouldn't return error, for example when starting
 		// bitmarkd first time, peer file doesn't exist.
 		if os.IsNotExist(err) {
 			return nil
@@ -148,6 +148,9 @@ func restorePeers(peerFile string) error {
 	}
 
 	for _, peer := range peers {
+		if IsPeerExpiredFromTime(peer.Timestamp) {
+			continue
+		}
 		addPeer(peer.PublicKey, peer.Listeners, peer.Timestamp)
 	}
 	return nil


### PR DESCRIPTION
When bitmarkd starts, it will add all peers from cache file. This modification will only add those peers that are not expired. Also refactor some functions with similar logic