### PR TITLE
Add regtest mode for local chain and be able to assign dedicate nodes

### DIFF
--- a/command/bitmarkd/bitmarkd.conf.sample
+++ b/command/bitmarkd/bitmarkd.conf.sample
@@ -55,6 +55,15 @@ https_allow = nil
 --     "::1/128",
 -- }
 
+p2p_bootstrap_nodes = {
+    bitcoin = {
+        "127.0.0.1:18444",
+    },
+    litecoin = {
+        "127.0.0.1:19444",
+    }
+}
+
 -- set log level default value
 --log_level = "error"
 

--- a/command/bitmarkd/bitmarkd.conf.sub
+++ b/command/bitmarkd/bitmarkd.conf.sub
@@ -310,6 +310,10 @@ M.payment = {
 
     -- the mode should be one of the following: p2p, discovery, rest
     mode = "p2p",
+    bootstrap_nodes = p2p_bootstrap_nodes or{
+        bitcoin = {},
+        litecoin = {}
+    },
 
     -- setup proxy addresses based on selected chain
     -- required if the mode is set to "rest"

--- a/currency/chain_test.go
+++ b/currency/chain_test.go
@@ -1,0 +1,73 @@
+package currency
+
+import (
+	"testing"
+
+	"github.com/bitmark-inc/bitmarkd/chain"
+)
+
+func TestBtcChainParams(t *testing.T) {
+
+	btcLocalParams := Bitcoin.ChainParam(chain.Local)
+
+	if "regtest" != btcLocalParams.Name {
+		t.Fatal("invalid network")
+	}
+
+	if 1 != btcLocalParams.HDCoinType {
+		t.Fatal("incorrect currency")
+	}
+
+	btcTestnetParams := Bitcoin.ChainParam(chain.Testing)
+
+	if "testnet3" != btcTestnetParams.Name {
+		t.Fatal("invalid network")
+	}
+
+	if 1 != btcTestnetParams.HDCoinType {
+		t.Fatal("incorrect currency")
+	}
+
+	btcMainnetParams := Bitcoin.ChainParam(chain.Bitmark)
+
+	if "mainnet" != btcMainnetParams.Name {
+		t.Fatal("invalid network")
+	}
+
+	if 0 != btcMainnetParams.HDCoinType {
+		t.Fatal("incorrect currency")
+	}
+}
+
+func TestLtcChainParams(t *testing.T) {
+
+	ltcLocalParams := Litecoin.ChainParam(chain.Local)
+
+	if "regtest" != ltcLocalParams.Name {
+		t.Fatal("invalid network")
+	}
+
+	if 1 != ltcLocalParams.HDCoinType {
+		t.Fatal("incorrect currency")
+	}
+
+	ltcTestnetParams := Litecoin.ChainParam(chain.Testing)
+
+	if "testnet4" != ltcTestnetParams.Name {
+		t.Fatal("invalid network")
+	}
+
+	if 1 != ltcTestnetParams.HDCoinType {
+		t.Fatal("incorrect currency")
+	}
+
+	ltcMainnetParams := Litecoin.ChainParam(chain.Bitmark)
+
+	if "mainnet" != ltcMainnetParams.Name {
+		t.Fatal("invalid network")
+	}
+
+	if 2 != ltcMainnetParams.HDCoinType {
+		t.Fatal("incorrect currency")
+	}
+}

--- a/payment/p2p_test.go
+++ b/payment/p2p_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/bitmark-inc/bitmarkd/chain"
 	"github.com/bitmark-inc/bitmarkd/currency"
 	"github.com/bitmark-inc/bitmarkd/fault"
 )
@@ -38,7 +39,7 @@ func NewDummyMsgBlock(previousBlock *chainhash.Hash, timestamp *time.Time) *wire
 func TestOnPeerBlockEarlyBlocks(t *testing.T) {
 	testCurrency := currency.Bitcoin
 
-	w, err := newP2pWatcher(testCurrency)
+	w, err := newP2pWatcher(testCurrency, []string{})
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -59,7 +60,7 @@ func TestOnPeerBlockEarlyBlocks(t *testing.T) {
 func TestOnPeerBlockHeaderNotFound(t *testing.T) {
 	testCurrency := currency.Bitcoin
 
-	w, err := newP2pWatcher(testCurrency)
+	w, err := newP2pWatcher(testCurrency, []string{})
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -82,7 +83,7 @@ func TestOnPeerBlockHeaderNotFound(t *testing.T) {
 func TestOnPeerBlockProcessed(t *testing.T) {
 	testCurrency := currency.Bitcoin
 
-	w, err := newP2pWatcher(testCurrency)
+	w, err := newP2pWatcher(testCurrency, []string{})
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -92,7 +93,7 @@ func TestOnPeerBlockProcessed(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	checkpoint := testCurrency.ChainParam(true).Checkpoints[0]
+	checkpoint := testCurrency.ChainParam(chain.Testing).Checkpoints[0]
 
 	// prepare checkpoint header in db
 	w.storage.StoreBlock(checkpoint.Height, checkpoint.Hash)
@@ -144,7 +145,7 @@ func TestExamineTx(t *testing.T) {
 
 	testCurrency := currency.Litecoin
 
-	w, err := newP2pWatcher(testCurrency)
+	w, err := newP2pWatcher(testCurrency, []string{})
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -187,7 +188,7 @@ func TestExamineTxWithoutPayment(t *testing.T) {
 
 	testCurrency := currency.Litecoin
 
-	w, err := newP2pWatcher(testCurrency)
+	w, err := newP2pWatcher(testCurrency, []string{})
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -202,7 +203,7 @@ func TestExamineTxWithoutPayment(t *testing.T) {
 func TestOnPeerNoHeaders(t *testing.T) {
 	testCurrency := currency.Litecoin
 
-	w, err := newP2pWatcher(testCurrency)
+	w, err := newP2pWatcher(testCurrency, []string{})
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -227,7 +228,7 @@ func TestOnPeerNoHeaders(t *testing.T) {
 func TestOnPeerAllOldHeaders(t *testing.T) {
 	testCurrency := currency.Litecoin
 
-	w, err := newP2pWatcher(testCurrency)
+	w, err := newP2pWatcher(testCurrency, []string{})
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -268,7 +269,7 @@ func TestOnPeerAllOldHeaders(t *testing.T) {
 func TestOnPeerInvalidPrevious(t *testing.T) {
 	testCurrency := currency.Litecoin
 
-	w, err := newP2pWatcher(testCurrency)
+	w, err := newP2pWatcher(testCurrency, []string{})
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -308,7 +309,7 @@ func TestOnPeerInvalidPrevious(t *testing.T) {
 func TestRollbackToHeight(t *testing.T) {
 	testCurrency := currency.Litecoin
 
-	w, err := newP2pWatcher(testCurrency)
+	w, err := newP2pWatcher(testCurrency, []string{})
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/payment/setup.go
+++ b/payment/setup.go
@@ -27,10 +27,16 @@ const (
 
 // Configuration - structure for configuration file
 type Configuration struct {
-	Mode      string                  `gluamapper:"mode" hcl:"mode" json:"mode"`
-	Discovery *discoveryConfiguration `gluamapper:"discovery" hcl:"discovery" json:"discovery"`
-	Bitcoin   *currencyConfiguration  `gluamapper:"bitcoin" hcl:"bitcoin" json:"bitcoin"`
-	Litecoin  *currencyConfiguration  `gluamapper:"litecoin" hcl:"litecoin" json:"litecoin"`
+	Mode           string                      `gluamapper:"mode" hcl:"mode" json:"mode"`
+	BootstrapNodes bootstrapNodesConfiguration `gluamapper:"bootstrap_nodes" hcl:"bootstrap_nodes" json:"bootstrap_nodes"`
+	Discovery      *discoveryConfiguration     `gluamapper:"discovery" hcl:"discovery" json:"discovery"`
+	Bitcoin        *currencyConfiguration      `gluamapper:"bitcoin" hcl:"bitcoin" json:"bitcoin"`
+	Litecoin       *currencyConfiguration      `gluamapper:"litecoin" hcl:"litecoin" json:"litecoin"`
+}
+
+type bootstrapNodesConfiguration struct {
+	Bitcoin  []string `gluamapper:"bitcoin" hcl:"bitcoin" json:"bitcoin"`
+	Litecoin []string `gluamapper:"litecoin" hcl:"litecoin" json:"litecoin"`
 }
 
 type discoveryConfiguration struct {
@@ -107,11 +113,11 @@ func Initialise(configuration *Configuration) error {
 	case "p2p":
 		globalData.log.Info("p2p watcher…")
 
-		btcP2pWatcher, err := newP2pWatcher(currency.Bitcoin)
+		btcP2pWatcher, err := newP2pWatcher(currency.Bitcoin, configuration.BootstrapNodes.Bitcoin)
 		if err != nil {
 			return err
 		}
-		ltcP2pWatcher, err := newP2pWatcher(currency.Litecoin)
+		ltcP2pWatcher, err := newP2pWatcher(currency.Litecoin, configuration.BootstrapNodes.Litecoin)
 		if err != nil {
 			return err
 		}

--- a/storage/payment.go
+++ b/storage/payment.go
@@ -124,17 +124,17 @@ func (l *LevelDBPaymentStore) Table(tableName string) *PaymentTable {
 // GetHeight returns height for a specific hash
 func (l *LevelDBPaymentStore) GetHeight(hash *chainhash.Hash) (int32, error) {
 	if hash == nil {
-		return 0, fault.HashCannotBeNil
+		return -1, fault.HashCannotBeNil
 	}
 
 	heightByte := l.Table("hash").Get(hash.CloneBytes())
 	if heightByte == nil {
-		return 0, nil
+		return -1, nil
 	}
 
 	h, err := strconv.ParseInt(string(heightByte), 16, 32)
 	if err != nil {
-		return 0, err
+		return -1, err
 	}
 
 	return int32(h), nil

--- a/storage/payment_test.go
+++ b/storage/payment_test.go
@@ -13,6 +13,40 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 )
 
+func TestPaymentStorageHeightNotFound(t *testing.T) {
+	hash, err := chainhash.NewHashFromStr("d10ff375832ef8ca311669c17d87b435000f3542ee0aa36028c1902d9a40cd40")
+	if err != nil {
+		t.Fatalf("unable create hash: %s", err.Error())
+	}
+
+	store := PaymentStorage.Btc
+	height, err := store.GetHeight(hash)
+	if -1 != height {
+		t.Fatalf("height value should be -1")
+	}
+
+	if err != nil {
+		t.Fatalf("errors during get height: %s", err.Error())
+	}
+}
+
+func TestPaymentStorageHashNotFound(t *testing.T) {
+	store := PaymentStorage.Btc
+	hash, err := store.GetHash(987)
+
+	if hash != nil {
+		t.Fatal("hash should be nil")
+	}
+
+	if err == nil {
+		t.Fatal("the error should be hash not found")
+	}
+
+	if err.Error() != "hash not found" {
+		t.Fatal("the error should be hash not found")
+	}
+}
+
 func TestPaymentStorageStoreBlock(t *testing.T) {
 	db := PaymentStorage.Btc.DB()
 


### PR DESCRIPTION
Since bitmarkd has an option to run a local chain, it is better to run it with a currency chains in regression test mode. In this PR, the bitmarkd will use `regtest` parameter of currency chains if the chain is set to `local`. In `regtest` mode, the client checkpoint will start from the genesis hash that is defined from bitcoin and litecoin network.

There is no DNS seed for bitcoin / litecoin regtest network. Thus, a new config is added in order to assign dedicated bitcoin and litecoin nodes. 