### PR TITLE
Make p2p peer cache folder configurable

### DIFF
--- a/command/bitmarkd/bitmarkd.conf.sub
+++ b/command/bitmarkd/bitmarkd.conf.sub
@@ -310,6 +310,10 @@ M.payment = {
 
     -- the mode should be one of the following: p2p, discovery, rest, noverify
     mode = "p2p",
+    p2p_cache = {
+        btc_directory = "btc-local",
+        ltc_directory = "ltc-local"
+    },
     bootstrap_nodes = p2p_bootstrap_nodes or{
         bitcoin = {},
         litecoin = {}

--- a/command/bitmarkd/bitmarkd.conf.sub
+++ b/command/bitmarkd/bitmarkd.conf.sub
@@ -311,8 +311,8 @@ M.payment = {
     -- the mode should be one of the following: p2p, discovery, rest, noverify
     mode = "p2p",
     p2p_cache = {
-        btc_directory = "btc-local",
-        ltc_directory = "ltc-local"
+        btc_directory = M.chain .. "-btc-cache",
+        ltc_directory = M.chain .. "-ltc-cache"
     },
     bootstrap_nodes = p2p_bootstrap_nodes or{
         bitcoin = {},

--- a/command/bitmarkd/configuration.go
+++ b/command/bitmarkd/configuration.go
@@ -39,8 +39,8 @@ const (
 	defaultTestingReservoirFile = "reservoir-" + chain.Testing + ".cache"
 	defaultLocalReservoirFile   = "reservoir-" + chain.Local + ".cache"
 
-	defaultBtcLocalDirectory = "btc-local"
-	defaultLtcLocalDirectory = "ltc-local"
+	defaultBitmarkBtcLocalDirectory = chain.Bitmark + "-btc-cache"
+	defaultBitmarkLtcLocalDirectory = chain.Bitmark + "-ltc-cache"
 
 	defaultLogDirectory = "log"
 	defaultLogFile      = "bitmarkd.log"
@@ -129,8 +129,8 @@ func getConfiguration(configurationFileName string) (*Configuration, error) {
 
 		Payment: payment.Configuration{
 			P2PCache: payment.P2PCache{
-				BtcDirectory: defaultBtcLocalDirectory,
-				LtcDirectory: defaultLtcLocalDirectory,
+				BtcDirectory: defaultBitmarkBtcLocalDirectory,
+				LtcDirectory: defaultBitmarkLtcLocalDirectory,
 			},
 		},
 

--- a/command/bitmarkd/configuration.go
+++ b/command/bitmarkd/configuration.go
@@ -39,6 +39,9 @@ const (
 	defaultTestingReservoirFile = "reservoir-" + chain.Testing + ".cache"
 	defaultLocalReservoirFile   = "reservoir-" + chain.Local + ".cache"
 
+	defaultBtcLocalDirectory = "btc-local"
+	defaultLtcLocalDirectory = "ltc-local"
+
 	defaultLogDirectory = "log"
 	defaultLogFile      = "bitmarkd.log"
 	defaultLogCount     = 10          //  number of log files retained
@@ -124,6 +127,13 @@ func getConfiguration(configurationFileName string) (*Configuration, error) {
 			PreferIPv6:         true,
 		},
 
+		Payment: payment.Configuration{
+			P2PCache: payment.P2PCache{
+				BtcDirectory: defaultBtcLocalDirectory,
+				LtcDirectory: defaultLtcLocalDirectory,
+			},
+		},
+
 		Logging: logger.Configuration{
 			Directory: defaultLogDirectory,
 			File:      defaultLogFile,
@@ -185,6 +195,8 @@ func getConfiguration(configurationFileName string) (*Configuration, error) {
 		&options.PeerFile,
 		&options.ReservoirFile,
 		&options.Database.Directory,
+		&options.Payment.P2PCache.BtcDirectory,
+		&options.Payment.P2PCache.LtcDirectory,
 		&options.Logging.Directory,
 	}
 	for _, f := range mustBeAbsolute {
@@ -224,6 +236,8 @@ func getConfiguration(configurationFileName string) (*Configuration, error) {
 	for _, d := range []*string{
 		&options.Database.Directory,
 		&options.Logging.Directory,
+		&options.Payment.P2PCache.BtcDirectory,
+		&options.Payment.P2PCache.LtcDirectory,
 	} {
 		*d = util.EnsureAbsolute(options.DataDirectory, *d)
 		if err := os.MkdirAll(*d, 0700); nil != err {

--- a/payment/p2p.go
+++ b/payment/p2p.go
@@ -61,7 +61,7 @@ type p2pWatcher struct {
 	shutdown     chan struct{}
 }
 
-func newP2pWatcher(c currency.Currency, bootstrapNodes []string) (*p2pWatcher, error) {
+func newP2pWatcher(c currency.Currency, peerDirectory string, bootstrapNodes []string) (*p2pWatcher, error) {
 	var attemptLock sync.Mutex
 	log := logger.New(c.String() + "_watcher")
 	var paymentStore storage.P2PStorage
@@ -82,7 +82,7 @@ func newP2pWatcher(c currency.Currency, bootstrapNodes []string) (*p2pWatcher, e
 	}
 	log.Tracef("watcher default port: %d", defaultPort)
 
-	addrManager := addrmgr.New(".", nil)
+	addrManager := addrmgr.New(peerDirectory, nil)
 
 	w := &p2pWatcher{
 		currency:       c,

--- a/payment/p2p_test.go
+++ b/payment/p2p_test.go
@@ -39,7 +39,7 @@ func NewDummyMsgBlock(previousBlock *chainhash.Hash, timestamp *time.Time) *wire
 func TestOnPeerBlockEarlyBlocks(t *testing.T) {
 	testCurrency := currency.Bitcoin
 
-	w, err := newP2pWatcher(testCurrency, []string{})
+	w, err := newP2pWatcher(testCurrency, ".", []string{})
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -60,7 +60,7 @@ func TestOnPeerBlockEarlyBlocks(t *testing.T) {
 func TestOnPeerBlockHeaderNotFound(t *testing.T) {
 	testCurrency := currency.Bitcoin
 
-	w, err := newP2pWatcher(testCurrency, []string{})
+	w, err := newP2pWatcher(testCurrency, ".", []string{})
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -83,7 +83,7 @@ func TestOnPeerBlockHeaderNotFound(t *testing.T) {
 func TestOnPeerBlockProcessed(t *testing.T) {
 	testCurrency := currency.Bitcoin
 
-	w, err := newP2pWatcher(testCurrency, []string{})
+	w, err := newP2pWatcher(testCurrency, ".", []string{})
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -145,7 +145,7 @@ func TestExamineTx(t *testing.T) {
 
 	testCurrency := currency.Litecoin
 
-	w, err := newP2pWatcher(testCurrency, []string{})
+	w, err := newP2pWatcher(testCurrency, ".", []string{})
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -188,7 +188,7 @@ func TestExamineTxWithoutPayment(t *testing.T) {
 
 	testCurrency := currency.Litecoin
 
-	w, err := newP2pWatcher(testCurrency, []string{})
+	w, err := newP2pWatcher(testCurrency, ".", []string{})
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -203,7 +203,7 @@ func TestExamineTxWithoutPayment(t *testing.T) {
 func TestOnPeerNoHeaders(t *testing.T) {
 	testCurrency := currency.Litecoin
 
-	w, err := newP2pWatcher(testCurrency, []string{})
+	w, err := newP2pWatcher(testCurrency, ".", []string{})
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -228,7 +228,7 @@ func TestOnPeerNoHeaders(t *testing.T) {
 func TestOnPeerAllOldHeaders(t *testing.T) {
 	testCurrency := currency.Litecoin
 
-	w, err := newP2pWatcher(testCurrency, []string{})
+	w, err := newP2pWatcher(testCurrency, ".", []string{})
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -269,7 +269,7 @@ func TestOnPeerAllOldHeaders(t *testing.T) {
 func TestOnPeerInvalidPrevious(t *testing.T) {
 	testCurrency := currency.Litecoin
 
-	w, err := newP2pWatcher(testCurrency, []string{})
+	w, err := newP2pWatcher(testCurrency, ".", []string{})
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -309,7 +309,7 @@ func TestOnPeerInvalidPrevious(t *testing.T) {
 func TestRollbackToHeight(t *testing.T) {
 	testCurrency := currency.Litecoin
 
-	w, err := newP2pWatcher(testCurrency, []string{})
+	w, err := newP2pWatcher(testCurrency, ".", []string{})
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/payment/setup.go
+++ b/payment/setup.go
@@ -25,9 +25,15 @@ const (
 	maximumBlockRate      = 500.0 // blocks per second
 )
 
+type P2PCache struct {
+	BtcDirectory string `gluamapper:"btc_directory" json:"btc_directory"`
+	LtcDirectory string `gluamapper:"ltc_directory" json:"ltc_directory"`
+}
+
 // Configuration - structure for configuration file
 type Configuration struct {
 	Mode           string                      `gluamapper:"mode" hcl:"mode" json:"mode"`
+	P2PCache       P2PCache                    `gluamapper:"p2p_cache" json:"p2p_cache"`
 	BootstrapNodes bootstrapNodesConfiguration `gluamapper:"bootstrap_nodes" hcl:"bootstrap_nodes" json:"bootstrap_nodes"`
 	Discovery      *discoveryConfiguration     `gluamapper:"discovery" hcl:"discovery" json:"discovery"`
 	Bitcoin        *currencyConfiguration      `gluamapper:"bitcoin" hcl:"bitcoin" json:"bitcoin"`
@@ -118,11 +124,15 @@ func Initialise(configuration *Configuration) error {
 	case "p2p":
 		globalData.log.Info("p2p watcher…")
 
-		btcP2pWatcher, err := newP2pWatcher(currency.Bitcoin, configuration.BootstrapNodes.Bitcoin)
+		btcP2pWatcher, err := newP2pWatcher(currency.Bitcoin,
+			configuration.P2PCache.BtcDirectory,
+			configuration.BootstrapNodes.Bitcoin)
 		if err != nil {
 			return err
 		}
-		ltcP2pWatcher, err := newP2pWatcher(currency.Litecoin, configuration.BootstrapNodes.Litecoin)
+		ltcP2pWatcher, err := newP2pWatcher(currency.Litecoin,
+			configuration.P2PCache.LtcDirectory,
+			configuration.BootstrapNodes.Litecoin)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
In this PR, we create a configuration for assign peer cache folders. 

By default, it uses the directory that runs bitmarkd to save the cache. Since the file name is fixed in btcd program, it would have problems like peer.json is override by accident. 

With the change, the `peers.json` for bitcoin and litecoin by default. Is is also possible to change it to your preferred places.