### PR TITLE
Fix incorrect magic number for litecoin mainnet

### DIFF
--- a/currency/chain.go
+++ b/currency/chain.go
@@ -99,7 +99,7 @@ var (
 
 	ltcMainNetParams = &chaincfg.Params{
 		Name:        "mainnet",
-		Net:         wire.MainNet,
+		Net:         wire.BitcoinNet(0xdbb6c0fb),
 		DefaultPort: "9333",
 		DNSSeeds: []chaincfg.DNSSeed{
 			{"seed-a.litecoin.loshan.co.uk", true},


### PR DESCRIPTION
Bitmarkd now fails to negotiate with litecoind node since the number is set to bitcoin one. This PR is going to fix the number 