### PR TITLE
Fix commands for `dns-txt` and `gen-peer-identity`

### DIFF
--- a/announce/tagparsing.go
+++ b/announce/tagparsing.go
@@ -37,7 +37,7 @@ type tagline struct {
 
 // decode DNS TXT records of these forms
 //
-//   <TAG> a=<IPv4;IPv6> c=<PORT> r=<PORT> f=<SHA3-256(cert)> p=<PUBLIC-KEY>
+//   <TAG> a=<IPv4;IPv6> c=<PORT> r=<PORT> f=<SHA3-256(cert)> i=<PEER-ID>
 //
 // other invalid combinations or extraneous items are ignored
 

--- a/command/bitmarkd/bitmarkd.conf.sample
+++ b/command/bitmarkd/bitmarkd.conf.sample
@@ -200,7 +200,6 @@ M.peering = {
         make_announcements(public_ip, 2136),
     },
 
-    public_key = read_file("peer.public"),
     private_key = read_file("peer.private"),
 
     -- dedicated static peer connections

--- a/command/bitmarkd/commands.go
+++ b/command/bitmarkd/commands.go
@@ -378,7 +378,7 @@ func dnsTXT(options *Configuration) {
 		exitwithstatus.Message("error: cannot generate private key: %q  error: %s", peering.PrivateKey, err)
 	}
 
-	peerID, err := peer.IDFromPublicKey(privateKey.GetPublic())
+	peerID, err := peer.IDFromPrivateKey(privateKey)
 	if err != nil {
 		exitwithstatus.Message("error: cannot generate peer id  error: %s", err)
 	}

--- a/command/bitmarkd/commands.go
+++ b/command/bitmarkd/commands.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"crypto/tls"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -20,9 +21,12 @@ import (
 	"github.com/bitmark-inc/bitmarkd/block"
 	"github.com/bitmark-inc/bitmarkd/blockheader"
 	"github.com/bitmark-inc/bitmarkd/fault"
+	"github.com/bitmark-inc/bitmarkd/util"
 	"github.com/bitmark-inc/bitmarkd/zmqutil"
 	"github.com/bitmark-inc/exitwithstatus"
 	"github.com/bitmark-inc/logger"
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/peer"
 )
 
 const (
@@ -51,14 +55,26 @@ func processSetupCommand(arguments []string) bool {
 
 	switch command {
 	case "gen-peer-identity", "peer":
-		publicKeyFilename := getFilenameWithDirectory(arguments, peerPublicKeyFilename)
 		privateKeyFilename := getFilenameWithDirectory(arguments, peerPrivateKeyFilename)
-		err := zmqutil.MakeKeyPair(publicKeyFilename, privateKeyFilename)
-		if nil != err {
-			fmt.Printf("generate private key: %q and public key: %q error: %s\n", privateKeyFilename, publicKeyFilename, err)
+
+		if util.EnsureFileExists(peerPrivateKeyFilename) {
+			fmt.Printf("generate private key: %q error: %s\n", privateKeyFilename, fault.ErrCertificateFileAlreadyExists)
 			exitwithstatus.Exit(1)
 		}
-		fmt.Printf("generated private key: %q and public key: %q\n", privateKeyFilename, publicKeyFilename)
+
+		key, err := util.MakeEd25519PeerKey()
+		if err != nil {
+			fmt.Printf("generate private key: %q error: %s\n", privateKeyFilename, err.Error())
+			exitwithstatus.Exit(1)
+		}
+
+		if err := ioutil.WriteFile(privateKeyFilename, []byte(key), 0600); err != nil {
+			os.Remove(privateKeyFilename)
+			fmt.Printf("generate private key: %q error: %s\n", privateKeyFilename, err.Error())
+			exitwithstatus.Exit(1)
+		}
+
+		fmt.Printf("generated private key: %q\n", privateKeyFilename)
 
 	case "gen-rpc-cert", "rpc":
 		certificateFilename := getFilenameWithDirectory(arguments, rpcCertificateKeyFilename)
@@ -330,7 +346,7 @@ func processDataCommand(log *logger.L, arguments []string, options *Configuratio
 // print out the DNS TXT record
 func dnsTXT(options *Configuration) {
 	//   <TAG> a=<IPv4;IPv6> c=<PEER-PORT> r=<RPC-PORT> f=<SHA3-256(cert)> p=<PUBLIC-KEY>
-	const txtRecord = `TXT "bitmark=v3 a=%s c=%d r=%d f=%x p=%x"` + "\n"
+	const txtRecord = `TXT "bitmark=v3 a=%s c=%d r=%d f=%x i=%s"` + "\n"
 
 	rpc := options.ClientRPC
 
@@ -352,9 +368,19 @@ func dnsTXT(options *Configuration) {
 
 	peering := options.Peering
 
-	publicKey, err := zmqutil.ReadPublicKey(peering.PublicKey)
-	if nil != err {
-		exitwithstatus.Message("error: cannot read public key: %q  error: %s", peering.PublicKey, err)
+	privateKeyBytes, err := hex.DecodeString(peering.PrivateKey)
+	if err != nil {
+		exitwithstatus.Message("error: cannot decode private key: %q  error: %s", peering.PrivateKey, err)
+	}
+
+	privateKey, err := crypto.UnmarshalPrivateKey(privateKeyBytes)
+	if err != nil {
+		exitwithstatus.Message("error: cannot generate private key: %q  error: %s", peering.PrivateKey, err)
+	}
+
+	peerID, err := peer.IDFromPublicKey(privateKey.GetPublic())
+	if err != nil {
+		exitwithstatus.Message("error: cannot generate peer id  error: %s", err)
 	}
 
 	if 0 == len(peering.Announce) {
@@ -380,11 +406,11 @@ func dnsTXT(options *Configuration) {
 
 	fmt.Printf("rpc fingerprint: %x\n", fingerprint)
 	fmt.Printf("rpc port:        %d\n", rpcPort)
-	fmt.Printf("public key:      %x\n", publicKey)
 	fmt.Printf("connect port:    %d\n", listenPort)
+	fmt.Printf("peer id:         %s\n", peerID)
 	fmt.Printf("IP4 IP6:         %s\n", IPs)
 
-	fmt.Printf(txtRecord, IPs, listenPort, rpcPort, fingerprint, publicKey)
+	fmt.Printf(txtRecord, IPs, listenPort, rpcPort, fingerprint, peerID)
 }
 
 // extract first IP4 and/or IP6 connection

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -65,7 +65,6 @@ type Configuration struct {
 	Listen             []string           `gluamapper:"listen" json:"listen"`
 	Announce           []string           `gluamapper:"announce" json:"announce"`
 	PrivateKey         string             `gluamapper:"private_key" json:"private_key"`
-	PublicKey          string             `gluamapper:"public_key" json:"public_key"` //TODO : REMOVE
 	Connect            []StaticConnection `gluamapper:"connect" json:"connect,omitempty"`
 }
 

--- a/util/peerKey.go
+++ b/util/peerKey.go
@@ -7,15 +7,21 @@ import (
 	crypto "github.com/libp2p/go-libp2p-core/crypto"
 )
 
-//GenEd25519Key Generate a random ED29919, 2048 key
-func GenEd25519Key() (crypto.PrivKey, error) {
+//GenEd25519Key Generate a random ED29919
+func MakeEd25519PeerKey() (string, error) {
 	r := rand.Reader
-	prvKey, _, err := crypto.GenerateKeyPairWithReader(crypto.Ed25519, 2048, r)
+	prvKey, _, err := crypto.GenerateKeyPairWithReader(crypto.Ed25519, 0, r)
 
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	return prvKey, nil
+
+	keyBytes, err := crypto.MarshalPrivateKey(prvKey)
+	if err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(keyBytes), nil
 }
 
 //DecodeHexToPrvKey decode a hex encoded key to a PrivKey


### PR DESCRIPTION
In the PR, it fixes the `dns-txt` command and update `gen-peer-identity` with the libp2p key.