### PR TITLE
Add publishing keypairs

### DIFF
--- a/command/bitmarkd/bitmarkd.conf.sub
+++ b/command/bitmarkd/bitmarkd.conf.sub
@@ -251,8 +251,8 @@ M.publishing = {
     },
 
     -- ok to use the same keys as peer
-    public_key = read_file("peer.public"),
-    private_key = read_file("peer.private")
+    public_key = read_file("publishing.public"),
+    private_key = read_file("publishing.private")
 }
 
 


### PR DESCRIPTION
Since we are using the zeromq for publish and subscribe, we have to separate the key between libp2p and zeromq. The `gen-peer-identity` command will now create those keys at the same time.