### PR TITLE
Libp2p dns peer

### DIFF
--- a/announce/announce_test.go
+++ b/announce/announce_test.go
@@ -38,7 +38,7 @@ func TestStorePeers(t *testing.T) {
 	curPath := os.Getenv("PWD")
 	peerFile := path.Join(curPath, "peers")
 	// domain from bind9
-	err := Initialise("nodes.test.bitmark.com", peerFile)
+	err := Initialise("nodes.test.bitmark.com", peerFile, false)
 	assert.NoError(t, err, "routing initialized error")
 	err = storePeers(peerFile)
 	assert.NoError(t, err, "routing backupPeers error")

--- a/announce/announcer.go
+++ b/announce/announcer.go
@@ -27,7 +27,7 @@ const (
 	announceInterval = 3 * time.Minute
 	//announceExpiry   = 5 * announceInterval // if no responses received within this time, delete the entry
 	announceExpiry  = 5 * announceInterval
-	MinTreeExpected = 9 //reference : voting minimumClients + 1(self)
+	MinTreeExpected = 5 + 1 //reference : voting minimumClients + 1(self)
 )
 
 type announcer struct {

--- a/announce/announcer.go
+++ b/announce/announcer.go
@@ -140,7 +140,7 @@ func (ann *announcer) process() {
 	// announce this nodes IP and ports to other peers
 	if globalData.rpcsSet {
 		log.Debugf("send rpc: %x", globalData.fingerprint)
-		if globalData.dnsPeerOnly == UsePeers //Make self a  hiden rpc node to avoid been connected
+		if globalData.dnsPeerOnly == UsePeers { //Make self a  hiden rpc node to avoid been connected
 			messagebus.Bus.P2P.Send("rpc", globalData.fingerprint[:], globalData.rpcs, timestamp)
 		}
 	}

--- a/announce/announcer.go
+++ b/announce/announcer.go
@@ -140,7 +140,7 @@ func (ann *announcer) process() {
 	// announce this nodes IP and ports to other peers
 	if globalData.rpcsSet {
 		log.Debugf("send rpc: %x", globalData.fingerprint)
-		if !globalData.dnsPeerOnly { //Make self a  hiden rpc node to avoid been connected
+		if globalData.dnsPeerOnly == UsePeers //Make self a  hiden rpc node to avoid been connected
 			messagebus.Bus.P2P.Send("rpc", globalData.fingerprint[:], globalData.rpcs, timestamp)
 		}
 	}
@@ -149,7 +149,7 @@ func (ann *announcer) process() {
 		idBinary, errID := globalData.peerID.MarshalBinary()
 		if nil == errAddr && nil == errID {
 			util.LogInfo(log, util.CoYellow, fmt.Sprintf("-><-send self data to P2P ID:%v address:%v", globalData.peerID.ShortString(), util.PrintMaAddrs(globalData.listeners)))
-			if !globalData.dnsPeerOnly { //Make self a  hiden node to avoid been connected
+			if globalData.dnsPeerOnly == UsePeers { //Make self a  hiden node to avoid been connected
 				messagebus.Bus.P2P.Send("peer", idBinary, addrsBinary, timestamp)
 			}
 		}

--- a/announce/announcer.go
+++ b/announce/announcer.go
@@ -139,17 +139,20 @@ func (ann *announcer) process() {
 	// announce this nodes IP and ports to other peers
 	if globalData.rpcsSet {
 		log.Debugf("send rpc: %x", globalData.fingerprint)
-		messagebus.Bus.P2P.Send("rpc", globalData.fingerprint[:], globalData.rpcs, timestamp)
+		if !globalData.dnsPeerOnly { //Make self a  hiden rpc node to avoid been connected
+			messagebus.Bus.P2P.Send("rpc", globalData.fingerprint[:], globalData.rpcs, timestamp)
+		}
 	}
 	if globalData.peerSet {
 		addrsBinary, errAddr := proto.Marshal(&Addrs{Address: util.GetBytesFromMultiaddr(globalData.listeners)})
 		idBinary, errID := globalData.peerID.MarshalBinary()
 		if nil == errAddr && nil == errID {
 			util.LogInfo(log, util.CoYellow, fmt.Sprintf("-><-send self data to P2P ID:%v address:%v", globalData.peerID.ShortString(), util.PrintMaAddrs(globalData.listeners)))
-			messagebus.Bus.P2P.Send("peer", idBinary, addrsBinary, timestamp)
+			if !globalData.dnsPeerOnly { //Make self a  hiden node to avoid been connected
+				messagebus.Bus.P2P.Send("peer", idBinary, addrsBinary, timestamp)
+			}
 		}
 	}
-
 	expireRPC()
 	expirePeer(log)
 

--- a/announce/setup.go
+++ b/announce/setup.go
@@ -76,6 +76,8 @@ type announcerData struct {
 
 	// set once during initialise
 	initialised bool
+	// only use dns record as peer nodes
+	dnsPeerOnly bool
 }
 
 // global data
@@ -87,7 +89,7 @@ const timeFormat = "2006-01-02 15:04:05"
 // Initialise - set up the announcement system
 // pass a fully qualified domain for root node list
 // or empty string for no root nodes
-func Initialise(nodesDomain, cacheDirectory string) error {
+func Initialise(nodesDomain, cacheDirectory string, dnsPeerOnly bool) error {
 
 	globalData.Lock()
 	defer globalData.Unlock()
@@ -110,11 +112,13 @@ func Initialise(nodesDomain, cacheDirectory string) error {
 	globalData.peerSet = false
 	globalData.rpcsSet = false
 	globalData.peerFile = path.Join(cacheDirectory, peerFile)
+	globalData.dnsPeerOnly = dnsPeerOnly
 
 	globalData.log.Info("start restoring peer data…")
-	if _, err := restorePeers(globalData.peerFile); err != nil {
-
-		globalData.log.Errorf("fail to restore peer data: %s", err.Error())
+	if !globalData.dnsPeerOnly { //disable restore to avoid restore non-dns node
+		if _, err := restorePeers(globalData.peerFile); err != nil {
+			globalData.log.Errorf("fail to restore peer data: %s", err.Error())
+		}
 	}
 
 	if err := globalData.nodesLookup.initialise(nodesDomain); nil != err {

--- a/announce/setup.go
+++ b/announce/setup.go
@@ -21,6 +21,13 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
+type dnsOnlyType bool
+
+const (
+	DnsOnly  dnsOnlyType = true
+	UsePeers dnsOnlyType = false
+)
+
 // type of listener
 const (
 	TypeRPC  = iota
@@ -77,7 +84,7 @@ type announcerData struct {
 	// set once during initialise
 	initialised bool
 	// only use dns record as peer nodes
-	dnsPeerOnly bool
+	dnsPeerOnly dnsOnlyType
 }
 
 // global data
@@ -89,7 +96,7 @@ const timeFormat = "2006-01-02 15:04:05"
 // Initialise - set up the announcement system
 // pass a fully qualified domain for root node list
 // or empty string for no root nodes
-func Initialise(nodesDomain, cacheDirectory string, dnsPeerOnly bool) error {
+func Initialise(nodesDomain, cacheDirectory string, dnsPeerOnly dnsOnlyType) error {
 
 	globalData.Lock()
 	defer globalData.Unlock()
@@ -112,10 +119,11 @@ func Initialise(nodesDomain, cacheDirectory string, dnsPeerOnly bool) error {
 	globalData.peerSet = false
 	globalData.rpcsSet = false
 	globalData.peerFile = path.Join(cacheDirectory, peerFile)
+
 	globalData.dnsPeerOnly = dnsPeerOnly
 
 	globalData.log.Info("start restoring peer data…")
-	if !globalData.dnsPeerOnly { //disable restore to avoid restore non-dns node
+	if globalData.dnsPeerOnly == UsePeers { //disable restore to avoid restore non-dns node
 		if _, err := restorePeers(globalData.peerFile); err != nil {
 			globalData.log.Errorf("fail to restore peer data: %s", err.Error())
 		}

--- a/announce/storepeers.go
+++ b/announce/storepeers.go
@@ -6,6 +6,7 @@
 package announce
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -88,6 +89,7 @@ loop:
 		if err != nil || nil != maAddrs {
 			continue loop
 		}
+		util.LogDebug(globalData.log, util.CoReset, fmt.Sprintf("restore peer ID:%s", id.ShortString()))
 		addPeer(id, maAddrs, peer.Timestamp)
 		globalData.peerTree.Print(false)
 	}

--- a/command/bitmarkd/bitmarkd.conf.sub
+++ b/command/bitmarkd/bitmarkd.conf.sub
@@ -132,6 +132,7 @@ M.cache_directory = M.chain .. "-cache"
 -- fast sync mode introduces a new mechanism for initial synchronization
 -- that speeds up the bitmark node to get it ready operating.
 M.fast_sync = true
+M.dns_peers_only = false
 
 -- for JSON clients on TLS connection
 M.client_rpc = {

--- a/command/bitmarkd/configuration.go
+++ b/command/bitmarkd/configuration.go
@@ -77,15 +77,15 @@ type Configuration struct {
 	Fastsync      bool         `gluamapper:"fast_sync" json:"fast_sync"`
 	Database      DatabaseType `gluamapper:"database" json:"database"`
 
-	CacheDirectory string `gluamapper:"cache_directory" json:"cache_directory"`
-
-	ClientRPC  rpc.RPCConfiguration   `gluamapper:"client_rpc" json:"client_rpc"`
-	HttpsRPC   rpc.HTTPSConfiguration `gluamapper:"https_rpc" json:"https_rpc"`
-	Peering    p2p.Configuration      `gluamapper:"peering" json:"peering"`
-	Publishing publish.Configuration  `gluamapper:"publishing" json:"publishing"`
-	Proofing   proof.Configuration    `gluamapper:"proofing" json:"proofing"`
-	Payment    payment.Configuration  `gluamapper:"payment" json:"payment"`
-	Logging    logger.Configuration   `gluamapper:"logging" json:"logging"`
+	CacheDirectory string                 `gluamapper:"cache_directory" json:"cache_directory"`
+	DNSPeerOnly    bool                   `gluamapper:"dns_peers_only" json:"dns_peers_only"`
+	ClientRPC      rpc.RPCConfiguration   `gluamapper:"client_rpc" json:"client_rpc"`
+	HttpsRPC       rpc.HTTPSConfiguration `gluamapper:"https_rpc" json:"https_rpc"`
+	Peering        p2p.Configuration      `gluamapper:"peering" json:"peering"`
+	Publishing     publish.Configuration  `gluamapper:"publishing" json:"publishing"`
+	Proofing       proof.Configuration    `gluamapper:"proofing" json:"proofing"`
+	Payment        payment.Configuration  `gluamapper:"payment" json:"payment"`
+	Logging        logger.Configuration   `gluamapper:"logging" json:"logging"`
 }
 
 // will read decode and verify the configuration

--- a/command/bitmarkd/main.go
+++ b/command/bitmarkd/main.go
@@ -264,7 +264,7 @@ func main() {
 		// trying to fetch the TXT records for validation
 		nodesDomain = masterConfiguration.Nodes // just assume it is a domain name
 	}
-	err = announce.Initialise(nodesDomain, masterConfiguration.CacheDirectory)
+	err = announce.Initialise(nodesDomain, masterConfiguration.CacheDirectory, masterConfiguration.DNSPeerOnly)
 	if nil != err {
 		log.Criticalf("announce initialise error: %s", err)
 		exitwithstatus.Message("announce initialise error: %s", err)
@@ -285,7 +285,7 @@ func main() {
 		log.Criticalf("zmq.AuthStart: error: %s", err)
 		exitwithstatus.Message("zmq.AuthStart: error: %s", err)
 	}
-	err = p2p.Initialise(&masterConfiguration.Peering, version, masterConfiguration.Fastsync)
+	err = p2p.Initialise(&masterConfiguration.Peering, version, masterConfiguration.Fastsync, masterConfiguration.DNSPeerOnly)
 	if nil != err {
 		log.Criticalf("p2p initialise error: %s", err)
 		exitwithstatus.Message("p2p initialise error: %s", err)

--- a/command/bitmarkd/main.go
+++ b/command/bitmarkd/main.go
@@ -264,7 +264,12 @@ func main() {
 		// trying to fetch the TXT records for validation
 		nodesDomain = masterConfiguration.Nodes // just assume it is a domain name
 	}
-	err = announce.Initialise(nodesDomain, masterConfiguration.CacheDirectory, masterConfiguration.DNSPeerOnly)
+	if masterConfiguration.DNSPeerOnly {
+		err = announce.Initialise(nodesDomain, masterConfiguration.CacheDirectory, announce.DnsOnly)
+	} else {
+		err = announce.Initialise(nodesDomain, masterConfiguration.CacheDirectory, announce.UsePeers)
+	}
+
 	if nil != err {
 		log.Criticalf("announce initialise error: %s", err)
 		exitwithstatus.Message("announce initialise error: %s", err)
@@ -285,7 +290,12 @@ func main() {
 		log.Criticalf("zmq.AuthStart: error: %s", err)
 		exitwithstatus.Message("zmq.AuthStart: error: %s", err)
 	}
-	err = p2p.Initialise(&masterConfiguration.Peering, version, masterConfiguration.Fastsync, masterConfiguration.DNSPeerOnly)
+	if masterConfiguration.DNSPeerOnly {
+		err = p2p.Initialise(&masterConfiguration.Peering, version, masterConfiguration.Fastsync, p2p.DnsOnly)
+	} else {
+		err = p2p.Initialise(&masterConfiguration.Peering, version, masterConfiguration.Fastsync, p2p.UsePeers)
+	}
+
 	if nil != err {
 		log.Criticalf("p2p initialise error: %s", err)
 		exitwithstatus.Message("p2p initialise error: %s", err)

--- a/p2p/connector.go
+++ b/p2p/connector.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bitmark-inc/bitmarkd/util"
 
 	"github.com/libp2p/go-libp2p-core/peer"
-	"github.com/multiformats/go-multiaddr"
 )
 
 //DirectConnect connect to the peer with given peer AddrInfo
@@ -54,21 +53,6 @@ func (n *Node) isSameNode(info peer.AddrInfo) bool {
 		// Compare local listener address
 		for _, a := range n.Host.Addrs() {
 			if strings.Contains(cmpr.String(), a.String()) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-//IsPeerExisted peer is existed in the Peerstore
-func (n *Node) IsPeerExisted(newAddr multiaddr.Multiaddr) bool {
-	//TODO: refactor nested loop
-	for _, ID := range n.Host.Peerstore().Peers() {
-		for _, addr := range n.Host.Peerstore().PeerInfo(ID).Addrs {
-			//	Log.Debugf("peers in PeerStore:%s     NewAddress:%s\n", addr.String(), newAddr.String())
-			if addr.Equal(newAddr) {
-				n.Log.Info("Peer is in PeerStore")
 				return true
 			}
 		}

--- a/p2p/listener.go
+++ b/p2p/listener.go
@@ -175,6 +175,8 @@ func (l *ListenHandler) handleStream(stream network.Stream) {
 			if nType != "client" {
 				announce.AddPeer(reqID, reqMaAddrs, timestamp) // id, listeners, timestam
 			}
+			l.node.addRegister(reqID)
+
 			randPeerID, randListeners, randTs, err := announce.GetRandom(reqID)
 			var randData [][]byte
 			var packError error
@@ -192,9 +194,12 @@ func (l *ListenHandler) handleStream(stream network.Stream) {
 				listenerSendError(rw, nodeChain, err, "-><- Radom node", log)
 				break
 			}
-			l.node.addRegister(reqID)
 			_, err = rw.Write(p2pMessagePacked)
-			util.LogError(log, util.CoReset, fmt.Sprintf("Register ID:%s Write Error:%v", reqID.ShortString(), err))
+			if err != nil {
+				listenerSendError(rw, nodeChain, err, "-><- Radom node", log)
+				break
+			}
+			util.LogDebug(log, util.CoReset, fmt.Sprintf("-->> send a random node ID:%s", reqID.ShortString()))
 			rw.Flush()
 
 		default: // other commands as subscription-type commands // this will move to pubsub

--- a/p2p/metricsVoting.go
+++ b/p2p/metricsVoting.go
@@ -69,7 +69,6 @@ loop:
 		case <-shutdown:
 			continue loop
 		case <-delay: //update voting metrics
-			//util.LogWarn(log, util.CoCyan, "MetricsPeersVoting  routine interval...")
 			delay = time.After(votingCycleInterval)
 			p.UpdateCandidates()
 			if nil == p.Candidates {

--- a/p2p/multicastSub.go
+++ b/p2p/multicastSub.go
@@ -107,6 +107,11 @@ loop:
 			}
 			messagebus.Bus.Announce.Send("addrpc", parameters[0], parameters[1], parameters[2])
 		case "peer":
+			if n.dnsPeerOnly {
+				util.LogDebug(log, util.CoReset, "-->> peer is discard : dnsPeerOnly")
+				continue loop
+			}
+
 			if dataLength < 3 {
 				util.LogWarn(log, util.CoLightRed, fmt.Sprintf("-->>peer with too few data: %d items", dataLength))
 				continue loop

--- a/p2p/multicastSub.go
+++ b/p2p/multicastSub.go
@@ -107,7 +107,7 @@ loop:
 			}
 			messagebus.Bus.Announce.Send("addrpc", parameters[0], parameters[1], parameters[2])
 		case "peer":
-			if n.dnsPeerOnly {
+			if n.dnsPeerOnly == DnsOnly {
 				util.LogDebug(log, util.CoReset, "-->> peer is discard : dnsPeerOnly")
 				continue loop
 			}

--- a/p2p/nodeImpl.go
+++ b/p2p/nodeImpl.go
@@ -19,9 +19,10 @@ import (
 )
 
 //Setup setup a node
-func (n *Node) Setup(configuration *Configuration, version string, fastsync bool) error {
+func (n *Node) Setup(configuration *Configuration, version string, fastsync bool, dnsPeerOnly dnsOnlyType) error {
 	globalData.Version = version
 	globalData.NodeType = configuration.NodeType
+	globalData.dnsPeerOnly = dnsPeerOnly
 	maAddrs := IPPortToMultiAddr(configuration.Listen)
 	n.Registers = make(map[peerlib.ID]RegisterStatus)
 	prvKey, err := util.DecodePrivKeyFromHex(configuration.PrivateKey) //Hex Decoded binaryString

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -85,6 +85,7 @@ type Node struct {
 	metricsVoting MetricsPeersVoting
 	// statemachine
 	concensusMachine Machine
+	dnsPeerOnly      bool
 }
 
 // Connected - representation of a connected Peer (For Http RPC)
@@ -94,13 +95,14 @@ type Connected struct {
 }
 
 // Initialise initialize p2p module
-func Initialise(configuration *Configuration, version string, fastsync bool) error {
+func Initialise(configuration *Configuration, version string, fastsync bool, dnsPeerOnly bool) error {
 	globalData.Lock()
 	defer globalData.Unlock()
 	if globalData.initialised {
 		return fault.AlreadyInitialised
 	}
 	globalData.Log = logger.New("p2p")
+	globalData.dnsPeerOnly = dnsPeerOnly
 	globalData.Log.Info("starting…")
 	globalData.Setup(configuration, version, fastsync)
 	globalData.Log.Info("start background…")

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -40,6 +40,13 @@ var (
 	nodeProtocol = ma.ProtocolWithCode(ma.P_P2P).Name
 )
 
+type dnsOnlyType bool
+
+const (
+	DnsOnly  dnsOnlyType = true
+	UsePeers dnsOnlyType = false
+)
+
 // StaticConnection - hardwired connections
 // this is read from the configuration file
 type StaticConnection struct {
@@ -85,7 +92,7 @@ type Node struct {
 	metricsVoting MetricsPeersVoting
 	// statemachine
 	concensusMachine Machine
-	dnsPeerOnly      bool
+	dnsPeerOnly      dnsOnlyType
 }
 
 // Connected - representation of a connected Peer (For Http RPC)
@@ -95,16 +102,16 @@ type Connected struct {
 }
 
 // Initialise initialize p2p module
-func Initialise(configuration *Configuration, version string, fastsync bool, dnsPeerOnly bool) error {
+func Initialise(configuration *Configuration, version string, fastsync bool, dnsPeerOnly dnsOnlyType) error {
 	globalData.Lock()
 	defer globalData.Unlock()
 	if globalData.initialised {
 		return fault.AlreadyInitialised
 	}
 	globalData.Log = logger.New("p2p")
-	globalData.dnsPeerOnly = dnsPeerOnly
+
 	globalData.Log.Info("starting…")
-	globalData.Setup(configuration, version, fastsync)
+	globalData.Setup(configuration, version, fastsync, dnsPeerOnly)
 	globalData.Log.Info("start background…")
 
 	processes := background.Processes{

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -177,7 +177,7 @@ loop:
 			default: //peers to connect
 				if "N1" == item.Command || "N3" == item.Command || "X1" == item.Command || "X2" == item.Command ||
 					"X3" == item.Command || "X4" == item.Command || "X5" == item.Command || "X6" == item.Command ||
-					"X7" == item.Command || "P1" == item.Command || "P2" == item.Command {
+					"X7" == item.Command || "P1" == item.Command || "P2" == item.Command || "ES" == item.Command {
 					peerID, err := peerlib.IDFromBytes(item.Parameters[0])
 					util.LogInfo(n.Log, util.CoYellow, fmt.Sprintf("Recieve Command:%v ID:%v", item.Command, peerID.ShortString()))
 					if err != nil {

--- a/p2p/p2pUpstream.go
+++ b/p2p/p2pUpstream.go
@@ -153,9 +153,13 @@ func (n *Node) RequestRegister(id peerlib.ID, stream network.Stream, readwriter 
 	case "R":
 		nType, randID, randAddrs, randTs, err := UnPackRegisterData(parameters)
 		if err != nil {
+			n.unRegister(id)
 			return nil, err
 		}
 		n.addRegister(id)
+		if n.dnsPeerOnly { // Do not add a random node when the only dns peer  is needed
+			return s, nil
+		}
 		if !util.IDEqual(randID, id) {
 			// peer return the info, register send. don't add into peer tree
 			if nType != "client" { // client does not in the peer Tree

--- a/p2p/p2pUpstream.go
+++ b/p2p/p2pUpstream.go
@@ -157,7 +157,7 @@ func (n *Node) RequestRegister(id peerlib.ID, stream network.Stream, readwriter 
 			return nil, err
 		}
 		n.addRegister(id)
-		if n.dnsPeerOnly { // Do not add a random node when the only dns peer  is needed
+		if n.dnsPeerOnly == DnsOnly { // Do not add a random node when the only dns peer  is needed
 			return s, nil
 		}
 		if !util.IDEqual(randID, id) {

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -61,7 +61,7 @@ func TestIDMarshalUnmarshal(t *testing.T) {
 	assert.Equal(t, id.String(), id2.String(), "Convert ID fail")
 }
 func TestNewP2P(t *testing.T) {
-	err := Initialise(mockConfiguration("servant", 12136), "v1.0.0", false)
+	err := Initialise(mockConfiguration("servant", 12136), "v1.0.0", false, false)
 	assert.NoError(t, err, "P2P  initialized error")
 	time.Sleep(8 * time.Second)
 	defer announce.Finalise()


### PR DESCRIPTION
DNS Peers Only Feature
------------------------------
    Make this node a  hidden node and its peer tree has only nodes in DNS records.  Mainly for CTBC

CHANGE-LOG
--------------------------
Configuration: dns_peers_only in bitmarkd.conf
Peer tree:  only has peers in DNS records
RPC client: no changes
Peerstore: disable loading peers.json to avoid none DNS nodes
Broadcasting: peer and RPC does not broadcast themself
exhaustive connection: send all tree nodes to a P2P module.  The feature is added because peer-tree does not change unless DNS records have changed. The "determineConnection" may not pick-up all nodes so a node may not be picked. This may be an issue when a node is under or equal to  minimum count of voting mechanism



