### PR TITLE
Count mined block

### DIFF
--- a/proof/proof_test.go
+++ b/proof/proof_test.go
@@ -3,4 +3,9 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package proof
+package proof_test
+
+import "testing"
+
+func TestMinedBlocks(t *testing.T) {
+}

--- a/proof/proof_test.go
+++ b/proof/proof_test.go
@@ -5,7 +5,15 @@
 
 package proof_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/bitmark-inc/bitmarkd/counter"
+
+	"github.com/bitmark-inc/bitmarkd/proof"
+	"github.com/stretchr/testify/assert"
+)
 
 func TestMinedBlocks(t *testing.T) {
+	assert.Equal(t, counter.Counter(0), proof.MinedBlocks(), "wrong init value")
 }

--- a/proof/proof_test.go
+++ b/proof/proof_test.go
@@ -19,5 +19,5 @@ func TestMinedBlocks(t *testing.T) {
 }
 
 func TestFailToValidateBlocks(t *testing.T) {
-	assert.Equal(t, counter.Counter(0), proof.FailToValidateBlocks(), "wrong init value")
+	assert.Equal(t, counter.Counter(0), proof.FailMinedBlocks(), "wrong init value")
 }

--- a/proof/proof_test.go
+++ b/proof/proof_test.go
@@ -18,6 +18,6 @@ func TestMinedBlocks(t *testing.T) {
 	assert.Equal(t, counter.Counter(0), proof.MinedBlocks(), "wrong init value")
 }
 
-func TestFailToValidateBlocks(t *testing.T) {
+func TestFailMinedBlocks(t *testing.T) {
 	assert.Equal(t, counter.Counter(0), proof.FailMinedBlocks(), "wrong init value")
 }

--- a/proof/proof_test.go
+++ b/proof/proof_test.go
@@ -17,3 +17,7 @@ import (
 func TestMinedBlocks(t *testing.T) {
 	assert.Equal(t, counter.Counter(0), proof.MinedBlocks(), "wrong init value")
 }
+
+func TestFailToValidateBlocks(t *testing.T) {
+	assert.Equal(t, counter.Counter(0), proof.FailToValidateBlocks(), "wrong init value")
+}

--- a/proof/setup.go
+++ b/proof/setup.go
@@ -84,7 +84,7 @@ func Initialise(configuration *Configuration) error {
 		&globalData.sub,
 	}
 
-	globalData.background = background.Start(processes, globalData.log)
+	globalData.background = background.Start(processes, nil)
 
 	return nil
 }

--- a/proof/submission.go
+++ b/proof/submission.go
@@ -23,12 +23,13 @@ const (
 )
 
 type submission struct {
-	log             *logger.L
-	sigSend         *zmq.Socket // signal send
-	sigReceive      *zmq.Socket // signal receive
-	socket4         *zmq.Socket
-	socket6         *zmq.Socket
-	minedBlockCount counter.Counter
+	log              *logger.L
+	sigSend          *zmq.Socket // signal send
+	sigReceive       *zmq.Socket // signal receive
+	socket4          *zmq.Socket
+	socket6          *zmq.Socket
+	minedBlockCount  counter.Counter
+	failedBlockCount counter.Counter
 }
 
 // initialise the submission
@@ -146,6 +147,8 @@ func (sub *submission) process(socket *zmq.Socket) {
 	// increase minedBlockCount
 	if ok {
 		sub.minedBlockCount.Increment()
+	} else {
+		sub.failedBlockCount.Increment()
 	}
 
 	response := struct {
@@ -173,4 +176,8 @@ func (sub *submission) process(socket *zmq.Socket) {
 
 func MinedBlocks() counter.Counter {
 	return globalData.sub.minedBlockCount
+}
+
+func FailToValidateBlocks() counter.Counter {
+	return globalData.sub.failedBlockCount
 }

--- a/proof/submission.go
+++ b/proof/submission.go
@@ -178,6 +178,6 @@ func MinedBlocks() counter.Counter {
 	return globalData.sub.minedBlockCount
 }
 
-func FailToValidateBlocks() counter.Counter {
+func FailMinedBlocks() counter.Counter {
 	return globalData.sub.failedBlockCount
 }

--- a/rpc/node.go
+++ b/rpc/node.go
@@ -75,6 +75,7 @@ type InfoReply struct {
 	Chain               string    `json:"chain"`
 	Mode                string    `json:"mode"`
 	Block               BlockInfo `json:"block"`
+	Miner               MinerInfo `json:"miner"`
 	RPCs                uint64    `json:"rpcs"`
 	Peers               uint64    `json:"peers"`
 	TransactionCounters Counters  `json:"transactionCounters"`
@@ -89,13 +90,18 @@ type InfoReply struct {
 type BlockInfo struct {
 	Height uint64 `json:"height"`
 	Hash   string `json:"hash"`
-	Mined  uint64 `json:"mined"`
 }
 
 // Counters - transaction counters
 type Counters struct {
 	Pending  int `json:"pending"`
 	Verified int `json:"verified"`
+}
+
+// MinerInfo - miner info, include success / failed mined block count
+type MinerInfo struct {
+	Success uint64 `json:"success"`
+	Failed  uint64 `json:"failed"`
 }
 
 // Info - return some information about this node
@@ -113,7 +119,10 @@ func (node *Node) Info(arguments *InfoArguments, reply *InfoReply) error {
 	reply.Block = BlockInfo{
 		Height: blockheader.Height(),
 		Hash:   block.LastBlockHash(),
-		Mined:  uint64(proof.MinedBlocks()),
+	}
+	reply.Miner = MinerInfo{
+		Success: uint64(proof.MinedBlocks()),
+		Failed:  uint64(proof.FailMinedBlocks()),
 	}
 	reply.RPCs = connectionCountRPC.Uint64()
 	reply.Peers = incoming + outgoing

--- a/rpc/node.go
+++ b/rpc/node.go
@@ -80,7 +80,7 @@ type InfoReply struct {
 	Peers               uint64    `json:"peers"`
 	TransactionCounters Counters  `json:"transactionCounters"`
 	Difficulty          float64   `json:"difficulty"`
-	Hashrate            float64   `json:"hashrate,omitempty"`
+	Hashrate            float64   `json:"hashrate"`
 	Version             string    `json:"version"`
 	Uptime              string    `json:"uptime"`
 	PublicKey           string    `json:"publicKey"`

--- a/rpc/node.go
+++ b/rpc/node.go
@@ -106,7 +106,7 @@ type MinerInfo struct {
 
 // Info - return some information about this node
 // only enough for clients to determine node state
-// for more detaile information use HTTP GET requests
+// for more detail information use HTTP GET requests
 func (node *Node) Info(arguments *InfoArguments, reply *InfoReply) error {
 
 	if err := rateLimit(node.limiter); nil != err {

--- a/rpc/node.go
+++ b/rpc/node.go
@@ -9,6 +9,8 @@ import (
 	"encoding/hex"
 	"time"
 
+	"github.com/bitmark-inc/bitmarkd/proof"
+
 	"golang.org/x/time/rate"
 
 	"github.com/bitmark-inc/bitmarkd/announce"
@@ -87,6 +89,7 @@ type InfoReply struct {
 type BlockInfo struct {
 	Height uint64 `json:"height"`
 	Hash   string `json:"hash"`
+	Mined  uint64 `json:"mined"`
 }
 
 // Counters - transaction counters
@@ -110,6 +113,7 @@ func (node *Node) Info(arguments *InfoArguments, reply *InfoReply) error {
 	reply.Block = BlockInfo{
 		Height: blockheader.Height(),
 		Hash:   block.LastBlockHash(),
+		Mined:  uint64(proof.MinedBlocks()),
 	}
 	reply.RPCs = connectionCountRPC.Uint64()
 	reply.Peers = incoming + outgoing


### PR DESCRIPTION
This patches counts fail/success block from current node. The value stores in memory and reset whenever node is restarted