### PR TITLE
Libp2p rename to server

### DIFF
--- a/block/store.go
+++ b/block/store.go
@@ -103,13 +103,13 @@ func StoreIncoming(packedBlock, packedNextBlock []byte, performRescan rescanType
 		globalData.log.Infof("previous difficulty: %f, current difficulty: %f", prevDifficulty, nextDifficulty)
 	}
 
-	if err := blockrecord.ValidIncomingDifficuty(header); err != nil {
+	if err := blockrecord.ValidIncomingDifficulty(header, mode.ChainName()); err != nil {
 		globalData.log.Errorf("incoming block difficulty %f different from local %f", header.Difficulty.Value(), difficulty.Current.Value())
 		return err
 	}
 
 	if !shouldFastSync {
-		if ok := digest.IsValidByDifficulty(header.Difficulty); !ok {
+		if ok := digest.IsValidByDifficulty(header.Difficulty, mode.ChainName()); !ok {
 			globalData.log.Warnf("digest error: %s", fault.InvalidBlockHeaderDifficulty)
 			return fault.InvalidBlockHeaderDifficulty
 		}

--- a/blockdigest/digest.go
+++ b/blockdigest/digest.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/bitmark-inc/bitmarkd/chain"
+
 	"github.com/bitmark-inc/bitmarkd/difficulty"
 	"github.com/bitmark-inc/bitmarkd/fault"
 	"github.com/bitmark-inc/go-argon2"
@@ -62,21 +64,25 @@ func (digest Digest) Cmp(difficulty *big.Int) int {
 }
 
 //IsEmpty - is digest empty
-func (d Digest) IsEmpty() bool {
-	return d == (Digest{})
+func (digest Digest) IsEmpty() bool {
+	return digest == (Digest{})
 }
 
 // IsValidByDifficulty - is digest valid by difficulty
-func (d Digest) IsValidByDifficulty(diff *difficulty.Difficulty) bool {
-	reversedDigest := reversed(d)
+func (digest Digest) IsValidByDifficulty(diff *difficulty.Difficulty, chainName string) bool {
+	if chainName == chain.Local {
+		return true
+	}
+
+	reversedDigest := reversed(digest)
 	bigEndian := new(big.Int)
 	bigEndian.SetBytes(reversedDigest[:])
 	return bigEndian.Cmp(diff.BigInt()) <= 0
 }
 
-func (d Digest) SmallerDigestThan(target Digest) bool {
-	for i := len(d) - 1; i >= 0; i-- {
-		if d[i] < target[i] {
+func (digest Digest) SmallerDigestThan(target Digest) bool {
+	for i := len(digest) - 1; i >= 0; i-- {
+		if digest[i] < target[i] {
 			return true
 		}
 	}
@@ -84,10 +90,10 @@ func (d Digest) SmallerDigestThan(target Digest) bool {
 }
 
 // internal function to return a reversed byte order copy of a digest
-func reversed(d Digest) []byte {
+func reversed(digest Digest) []byte {
 	result := make([]byte, Length)
 	for i := 0; i < Length; i += 1 {
-		result[i] = d[Length-1-i]
+		result[i] = digest[Length-1-i]
 	}
 	return result
 }

--- a/blockdigest/digest_test.go
+++ b/blockdigest/digest_test.go
@@ -11,6 +11,8 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/bitmark-inc/bitmarkd/chain"
+
 	"github.com/bitmark-inc/bitmarkd/blockdigest"
 	"github.com/bitmark-inc/bitmarkd/difficulty"
 	"github.com/stretchr/testify/assert"
@@ -194,11 +196,11 @@ func TestIsValidByDifficultyWhenValid(t *testing.T) {
 	diff := difficulty.New()
 	diff.Set(2)
 
-	actual := digest.IsValidByDifficulty(diff)
+	actual := digest.IsValidByDifficulty(diff, chain.Testing)
 	assert.Equal(t, true, actual, "valid digest by difficulty")
 }
 
-func TestIsValidByDifficultyWhenInValid(t *testing.T) {
+func TestIsValidByDifficultyWhenInvalidOnDifferentChain(t *testing.T) {
 	digest := blockdigest.Digest{
 		0xff, 0xff, 0xff, 0xff,
 		0xff, 0xff, 0xff, 0xff,
@@ -213,8 +215,11 @@ func TestIsValidByDifficultyWhenInValid(t *testing.T) {
 	diff := difficulty.New()
 	diff.Set(2)
 
-	ok := digest.IsValidByDifficulty(diff)
+	ok := digest.IsValidByDifficulty(diff, chain.Testing)
 	assert.Equal(t, false, ok, "invalid digest by difficulty")
+
+	ok = digest.IsValidByDifficulty(diff, chain.Local)
+	assert.Equal(t, true, ok, "invalid digest by difficulty")
 }
 
 func TestIsEmptyWhenEmpty(t *testing.T) {

--- a/blockrecord/validator.go
+++ b/blockrecord/validator.go
@@ -7,6 +7,7 @@ package blockrecord
 
 import (
 	"github.com/bitmark-inc/bitmarkd/blockdigest"
+	"github.com/bitmark-inc/bitmarkd/chain"
 	"github.com/bitmark-inc/bitmarkd/difficulty"
 	"github.com/bitmark-inc/bitmarkd/fault"
 )
@@ -33,9 +34,13 @@ func ValidBlockTimeSpacingAtVersion(version uint16, timeSpacing uint64) error {
 	return nil
 }
 
-// ValidIncomingDifficuty - valid incoming difficulty
-func ValidIncomingDifficuty(header *Header) error {
+// ValidIncomingDifficulty - valid incoming difficulty
+func ValidIncomingDifficulty(header *Header, chainName string) error {
 	if !IsDifficultyAppliedVersion(header.Version) {
+		return nil
+	}
+
+	if chainName == chain.Local {
 		return nil
 	}
 

--- a/blockrecord/validator_test.go
+++ b/blockrecord/validator_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/bitmark-inc/bitmarkd/blockdigest"
 	"github.com/bitmark-inc/bitmarkd/blockrecord"
+	"github.com/bitmark-inc/bitmarkd/chain"
 	"github.com/bitmark-inc/bitmarkd/difficulty"
 	"github.com/bitmark-inc/bitmarkd/fault"
 	"github.com/bitmark-inc/bitmarkd/merkle"
@@ -50,7 +51,7 @@ func TestValidBlockTimeSpacingWhenCurrentVersionInvalid(t *testing.T) {
 	assert.Equal(t, fault.InvalidBlockHeaderTimestamp, err, "invalid current block time spacing")
 }
 
-func TestValidIncomingDifficutyWhenDifficultyNotAppliedAndInvalid(t *testing.T) {
+func TestValidIncomingDifficultyWhenDifficultyNotAppliedAndInvalid(t *testing.T) {
 	difficulty.Current.Set(2)
 	incoming := difficulty.New()
 	incoming.Set(4)
@@ -59,12 +60,12 @@ func TestValidIncomingDifficutyWhenDifficultyNotAppliedAndInvalid(t *testing.T) 
 	header.Difficulty = incoming
 	header.Version = 2
 
-	err := blockrecord.ValidIncomingDifficuty(header)
+	err := blockrecord.ValidIncomingDifficulty(header, chain.Testing)
 
 	assert.Equal(t, nil, err, "invalid difficulty header checking")
 }
 
-func TestValidIncomingDifficutyWhenDifficultyAppliedAndValid(t *testing.T) {
+func TestValidIncomingDifficultyWhenDifficultyAppliedAndValid(t *testing.T) {
 	difficulty.Current.Set(2)
 	incoming := difficulty.New()
 	incoming.Set(2)
@@ -72,12 +73,12 @@ func TestValidIncomingDifficutyWhenDifficultyAppliedAndValid(t *testing.T) {
 	header := setupHeader()
 	header.Difficulty = incoming
 
-	err := blockrecord.ValidIncomingDifficuty(header)
+	err := blockrecord.ValidIncomingDifficulty(header, chain.Testing)
 
 	assert.Equal(t, nil, err, "valid incoming difficulty")
 }
 
-func TestValidIncomingDifficutyWhenDifficultyAppliedAndInValid(t *testing.T) {
+func TestValidIncomingDifficultyWhenDifficultyAppliedAndInValid(t *testing.T) {
 	difficulty.Current.Set(2)
 	incoming := difficulty.New()
 	incoming.Set(4)
@@ -85,9 +86,24 @@ func TestValidIncomingDifficutyWhenDifficultyAppliedAndInValid(t *testing.T) {
 	header := setupHeader()
 	header.Difficulty = incoming
 
-	err := blockrecord.ValidIncomingDifficuty(header)
+	err := blockrecord.ValidIncomingDifficulty(header, chain.Testing)
 
 	assert.Equal(t, fault.DifficultyDoesNotMatchCalculated, err, "invalid incoming difficulty")
+}
+
+func TestValidIncomingDifficultyWhenDifferentChain(t *testing.T) {
+	difficulty.Current.Set(2)
+	incoming := difficulty.New()
+	incoming.Set(4)
+
+	header := setupHeader()
+	header.Difficulty = incoming
+
+	err := blockrecord.ValidIncomingDifficulty(header, chain.Local)
+	assert.Equal(t, nil, err, "local difficulty not match")
+
+	err = blockrecord.ValidIncomingDifficulty(header, chain.Testing)
+	assert.Equal(t, fault.DifficultyDoesNotMatchCalculated, err, "local difficulty not match")
 }
 
 func TestIsDifficultyAppliedVersionWhenApplied(t *testing.T) {

--- a/command/bitmarkd/bitmarkd.conf.sub
+++ b/command/bitmarkd/bitmarkd.conf.sub
@@ -200,9 +200,8 @@ M.https_rpc = {
 
 -- peer-to-peer connections
 M.peering = {
-    -- set to false to prevent additional connections
-    dynamic_connections = true,
-
+    -- set node types (server|client)    
+    nodetype = "server",
     -- for incoming peer connections
     listen = {
         add_port("*", 2136),

--- a/command/bitmarkd/configuration.go
+++ b/command/bitmarkd/configuration.go
@@ -120,10 +120,6 @@ func getConfiguration(configurationFileName string) (*Configuration, error) {
 		HttpsRPC: rpc.HTTPSConfiguration{
 			MaximumConnections: defaultRPCClients,
 		},
-		//TODO:  Check P2P
-		Peering: p2p.Configuration{
-			DynamicConnections: true,
-		},
 
 		Payment: payment.Configuration{
 			P2PCache: payment.P2PCache{

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,29 @@
+bitmarkd (0.12.4-1ubuntu1) bionic; urgency=medium
+
+  * release version
+
+ -- Christopher Hall <hsw@bitmark.com>  Tue, 14 Jan 2020 04:53:09 +0000
+
+bitmarkd (0.12.4-rc.1-1ubuntu1) bionic; urgency=medium
+
+  * memory problems were fixed by litecoin changes in beta.3
+  * change to release candidate for further testing
+
+ -- Christopher Hall <hsw@bitmark.com>  Fri, 10 Jan 2020 01:26:28 +0000
+
+bitmarkd (0.12.4-beta.5-1ubuntu1) bionic; urgency=medium
+
+  * change get remote block hash error log to warning
+
+ -- Christopher Hall <hsw@bitmark.com>  Wed, 08 Jan 2020 04:08:15 +0000
+
+bitmarkd (0.12.4-beta.4-1ubuntu1) bionic; urgency=medium
+
+  * problem with dual stack OS FreeBSD, Linux and RPC.  Was only TCP4
+    change to be TCP46
+
+ -- Christopher Hall <hsw@bitmark.com>  Mon, 06 Jan 2020 02:22:48 +0000
+
 bitmarkd (0.12.4-beta.3-1ubuntu1) bionic; urgency=medium
 
   * fix litecoin mainnet magic number (#110)

--- a/doc/release-note-template.md
+++ b/doc/release-note-template.md
@@ -1,0 +1,26 @@
+# Release Notes
+
+# How to Upgrade
+
+If you are running an older version, ...
+
+# Downgrade warning
+
+# Notable changes
+
+## RPCs
+
+## Configuration options
+
+## BIP 1: bidirectional connection
+
+## Fast synchronization
+
+
+# Low-level changes
+
+
+## Tests
+
+
+# Change log

--- a/fault/fault.go
+++ b/fault/fault.go
@@ -182,6 +182,7 @@ var (
 	VotesWithZeroHeight                   = e("votes with zero height")
 	WrongNetworkForPublicKey              = e("wrong network for public key")
 	WrongPassword                         = e("wrong password")
+	WrongEndpointString                   = e("wrong zmq protocol string")
 	//P2P package errors
 	PrivateKeyIsNil            = e("private key is nil")
 	GenPublicKeyFromPrivateKey = e("generate public key from private key fail")

--- a/fault/fault.go
+++ b/fault/fault.go
@@ -198,6 +198,6 @@ var (
 	NoAnnounceAddress          = e("no announce address")
 	AddInfoNil                 = e("AddrInfo is nil")
 	NoAddress                  = e("No address")
-	PackRandomNodeFail         = e("pack random node fail")
-	PackDataError              = e("pack data error")
+	PackRandomNode             = e("pack random node fail")
+	InvalidNodeType            = e("invalid NodeType")
 )

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -47,6 +47,20 @@ const (
 	UsePeers dnsOnlyType = false
 )
 
+type nodeType string
+
+const (
+	ServerNode nodeType = "server"
+	ClientNode nodeType = "client"
+)
+
+func (t nodeType) String() string {
+	if t == ClientNode {
+		return string(ClientNode)
+	}
+	return string(ServerNode)
+}
+
 // StaticConnection - hardwired connections
 // this is read from the configuration file
 type StaticConnection struct {
@@ -57,13 +71,12 @@ type StaticConnection struct {
 // Configuration - a block of configuration data
 // this is read from the configuration file
 type Configuration struct {
-	NodeType           string             `gluamapper:"nodetype" json:"nodetype"`
-	Port               int                `gluamapper:"port" json:"port"`
-	DynamicConnections bool               `gluamapper:"dynamic_connections" json:"dynamic_connections"`
-	Listen             []string           `gluamapper:"listen" json:"listen"`
-	Announce           []string           `gluamapper:"announce" json:"announce"`
-	PrivateKey         string             `gluamapper:"private_key" json:"private_key"`
-	Connect            []StaticConnection `gluamapper:"connect" json:"connect,omitempty"`
+	NodeType   string             `gluamapper:"nodetype" json:"nodetype"`
+	Port       int                `gluamapper:"port" json:"port"`
+	Listen     []string           `gluamapper:"listen" json:"listen"`
+	Announce   []string           `gluamapper:"announce" json:"announce"`
+	PrivateKey string             `gluamapper:"private_key" json:"private_key"`
+	Connect    []StaticConnection `gluamapper:"connect" json:"connect,omitempty"`
 }
 
 // NodeType to inidcate a node is a servant or client
@@ -76,7 +89,7 @@ type RegisterStatus struct {
 //Node  A p2p node
 type Node struct {
 	Version      string
-	NodeType     string
+	NodeType     nodeType
 	Host         p2pcore.Host
 	Announce     []ma.Multiaddr
 	sync.RWMutex           // to allow locking
@@ -152,8 +165,8 @@ loop:
 					n.delRegister(displayID)
 					util.LogInfo(log, util.CoWhite, fmt.Sprintf("@D  ID:%v is deleted", displayID.ShortString()))
 				}
-			case "peer", "rpc": // only servant broadcast its peer and rpc
-				if n.NodeType == "client" {
+			case "peer", "rpc": // only server broadcast its peer and rpc
+				if ClientNode == n.NodeType {
 					break
 				}
 				fallthrough

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -35,18 +35,17 @@ func TestMain(m *testing.M) {
 
 func mockConfiguration(nType string, port int) *Configuration {
 	return &Configuration{
-		NodeType:           nType,
-		Port:               port,
-		DynamicConnections: true,
-		Listen:             []string{"0.0.0.0:2136", "[::]:2136"},
-		Announce:           []string{"118.163.120.180:2136", "[2001:b030:2303:100:699b:a02d:9230:d2cb]:2136"},
-		PrivateKey:         "080112406eb84a3845d33c2a389d7fbea425cbf882047a2ab13084562f06875db47b5fdc2e45a298e6cd0472eeb97cd023c723824e157869d81039794864987c05b212a8",
-		Connect:            []StaticConnection{},
+		NodeType:   nType,
+		Port:       port,
+		Listen:     []string{"0.0.0.0:2136", "[::]:2136"},
+		Announce:   []string{"118.163.120.180:2136", "[2001:b030:2303:100:699b:a02d:9230:d2cb]:2136"},
+		PrivateKey: "080112406eb84a3845d33c2a389d7fbea425cbf882047a2ab13084562f06875db47b5fdc2e45a298e6cd0472eeb97cd023c723824e157869d81039794864987c05b212a8",
+		Connect:    []StaticConnection{},
 	}
 }
 
 func TestIDMarshalUnmarshal(t *testing.T) {
-	conf := mockConfiguration("servant", 12136)
+	conf := mockConfiguration("server", 12136)
 	fmt.Println(conf.PrivateKey)
 	prvKey, err := util.DecodePrivKeyFromHex(conf.PrivateKey)
 	assert.NoError(t, err, "Decode Hex Key Error")
@@ -61,7 +60,7 @@ func TestIDMarshalUnmarshal(t *testing.T) {
 	assert.Equal(t, id.String(), id2.String(), "Convert ID fail")
 }
 func TestNewP2P(t *testing.T) {
-	err := Initialise(mockConfiguration("servant", 12136), "v1.0.0", false, false)
+	err := Initialise(mockConfiguration("server", 12136), "v1.0.0", false, false)
 	assert.NoError(t, err, "P2P  initialized error")
 	time.Sleep(8 * time.Second)
 	defer announce.Finalise()

--- a/proof/internal_hasher.go
+++ b/proof/internal_hasher.go
@@ -1,0 +1,103 @@
+package proof
+
+import (
+	"encoding/binary"
+	"encoding/json"
+
+	"github.com/bitmark-inc/bitmarkd/blockrecord"
+	"github.com/bitmark-inc/bitmarkd/fault"
+
+	zmq "github.com/pebbe/zmq4"
+)
+
+const (
+	internalHasherProtocol = zmq.PAIR
+)
+
+type hashingRequest struct {
+	Job    string
+	Header blockrecord.Header
+}
+
+// InternalHasher - this dummy hasher is for test usage
+type InternalHasher interface {
+	Initialise() error
+	Start()
+}
+
+type internalHasher struct {
+	endpointRequestStr string
+	endpointReplyStr   string
+	requestSocket      *zmq.Socket // receive hash request
+	replySocket        *zmq.Socket // send hash result reply
+}
+
+func (h *internalHasher) Initialise() error {
+	requestSocket, err := zmq.NewSocket(internalHasherProtocol)
+	if nil != err {
+		return err
+	}
+
+	err = requestSocket.Connect(h.endpointRequestStr)
+	if nil != err {
+		return err
+	}
+	h.requestSocket = requestSocket
+
+	replySocket, err := zmq.NewSocket(internalHasherProtocol)
+	if nil != err {
+		return err
+	}
+
+	err = replySocket.Bind(h.endpointReplyStr)
+	if nil != err {
+		return err
+	}
+	h.replySocket = replySocket
+
+	return nil
+}
+
+func (h *internalHasher) Start() {
+	go func() {
+		for i := 1; ; i++ {
+			msg, err := h.requestSocket.Recv(0)
+			if nil != err {
+				continue
+			}
+
+			var request hashingRequest
+			_ = json.Unmarshal([]byte(msg), &request)
+			nonce := make([]byte, blockrecord.NonceSize)
+			binary.LittleEndian.PutUint64(nonce, uint64(i))
+
+			reply := struct {
+				Request string
+				Job     string
+				Packed  []byte
+			}{
+				Request: "block.nonce",
+				Job:     request.Job,
+				Packed:  nonce,
+			}
+
+			replyData, _ := json.Marshal(reply)
+
+			_, err = h.replySocket.SendBytes(replyData, 0)
+			if nil != err {
+				continue
+			}
+		}
+	}()
+}
+
+func NewInternalHasherForTest(request, reply string) (InternalHasher, error) {
+	if request == reply {
+		return nil, fault.WrongEndpointString
+	}
+
+	return &internalHasher{
+		endpointRequestStr: request,
+		endpointReplyStr:   reply,
+	}, nil
+}

--- a/proof/internal_hasher_test.go
+++ b/proof/internal_hasher_test.go
@@ -1,0 +1,88 @@
+package proof_test
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"testing"
+
+	"github.com/bitmark-inc/bitmarkd/difficulty"
+	"github.com/bitmark-inc/bitmarkd/merkle"
+
+	"github.com/bitmark-inc/bitmarkd/blockrecord"
+
+	zmq "github.com/pebbe/zmq4"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/bitmark-inc/bitmarkd/proof"
+)
+
+const (
+	endpointRequestStr         = "inproc://internal-hasher-request-test"
+	endpointReplyStr           = "inproc://internal-hasher-reply-test"
+	testInproc1                = "inproc://test1"
+	testInproc2                = "inproc://test2"
+	wrongEndpointRequestString = "tcp://wrong-request"
+	wrongEndpointReplyString   = "tcp://wrong-reply"
+	nonceStart                 = 1
+	protocol                   = zmq.PAIR
+)
+
+func TestNewInternalHasherForTestWhenInvalidSameString(t *testing.T) {
+	_, err := proof.NewInternalHasherForTest(testInproc1, testInproc1)
+	assert.NotNil(t, err, "wrong new internal hasher")
+}
+
+func TestInternalHasherInitialiseWhenValidString(t *testing.T) {
+	h, _ := proof.NewInternalHasherForTest(testInproc1, testInproc2)
+	err := h.Initialise()
+
+	assert.Equal(t, nil, err, "wrong initialise")
+}
+
+func TestNewInternalHasherInitialiseWhenInvalidString(t *testing.T) {
+	h1, _ := proof.NewInternalHasherForTest(wrongEndpointRequestString, testInproc1)
+	err := h1.Initialise()
+
+	assert.NotNil(t, err, "wrong initialise")
+
+	h2, _ := proof.NewInternalHasherForTest(testInproc1, wrongEndpointReplyString)
+	err = h2.Initialise()
+
+	assert.NotNil(t, err, "wrong initialise")
+}
+
+func TestInternalHasherStart(t *testing.T) {
+	sender, _ := zmq.NewSocket(protocol)
+	_ = sender.Bind(endpointRequestStr)
+	receiver, _ := zmq.NewSocket(protocol)
+	_ = receiver.Connect(endpointReplyStr)
+
+	h, _ := proof.NewInternalHasherForTest(endpointRequestStr, endpointReplyStr)
+	_ = h.Initialise()
+
+	h.Start()
+
+	job := "job"
+	msg := &proof.PublishedItem{
+		Job: job,
+		Header: blockrecord.Header{
+			Difficulty: difficulty.New(),
+		},
+		TxZero: []byte{},
+		TxIds:  []merkle.Digest{},
+	}
+	sendData, _ := json.Marshal(msg)
+	_, _ = sender.SendBytes(sendData, 0)
+
+	receivedData, err := receiver.RecvMessageBytes(0)
+	assert.Nil(t, err, "non nil error")
+
+	var reply proof.SubmittedItem
+	_ = json.Unmarshal([]byte(receivedData[0]), &reply)
+	nonce := make([]byte, blockrecord.NonceSize)
+	binary.LittleEndian.PutUint64(nonce, uint64(nonceStart))
+
+	assert.Equal(t, job, reply.Job, "wrong job")
+	assert.Equal(t, nonce, reply.Packed, "wrong packed")
+}

--- a/proof/proof_test.go
+++ b/proof/proof_test.go
@@ -3,4 +3,21 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package proof
+package proof_test
+
+import (
+	"testing"
+
+	"github.com/bitmark-inc/bitmarkd/counter"
+
+	"github.com/bitmark-inc/bitmarkd/proof"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMinedBlocks(t *testing.T) {
+	assert.Equal(t, counter.Counter(0), proof.MinedBlocks(), "wrong init value")
+}
+
+func TestFailMinedBlocks(t *testing.T) {
+	assert.Equal(t, counter.Counter(0), proof.FailMinedBlocks(), "wrong init value")
+}

--- a/proof/queue.go
+++ b/proof/queue.go
@@ -119,7 +119,7 @@ search:
 		diff := entry.item.Header.Difficulty
 		log.Debugf("incoming block difficulty: %f", diff.Value())
 
-		if !digest.IsValidByDifficulty(diff) {
+		if !digest.IsValidByDifficulty(diff, mode.ChainName()) {
 			log.Infof("digest %s, difficulty %064x, digest not match difficulty criteria", digest.String(), diff.BigInt())
 			return
 		}

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,0 +1,78 @@
+# Release Notes
+
+Version: 0.12.4
+
+# How to Upgrade
+
+If upgrading from an older setup:
+
+* create a new `bitmarkd.conf` based on data from old configuration
+  and the template from the current install.  The file should be self
+  explanetarty, but there are some notes in the **Configuration
+  Options** section below.
+* install the `bitmarkd.conf.sub` in same direcory as `bitmarkd.conf`
+* clean up the `/var/lib/bitmarkd` working directory by:
+  + remove any json or cache files from the root of the data directory
+    as these will now be places in
+  + remove and blocks and index LevelDB files in the `data`
+    subdirectory
+
+The above actions will re-download the entire blockchain for the new format LevelDB
+
+
+# Downgrade warning
+
+If the blocks and index LevelDBs have been removed then a downgrade
+will have to reload the block chain.
+
+
+# Notable changes
+
+* Fix the `peers.json` corruption by relocating each blockchain's
+  version to its own subdirectory
+* Fix memory leak caused by Litecoin connection trying to use Bitcoin
+  peers
+* LevelDB layout improvements and fast download of block chain
+
+## Data
+
+The naming and location of data and cache files has been changed
+
+* all cache files are moved to deparate subdirectories for each blockchain
+  + Bitcoin `peers.json`
+  + Litecoin `peers.json`
+  + bitmarkd `peers.json` and `reservoir.cache`
+* the `blocks` and `index` LevelDBs have been merged to a single
+  `bitmark` LevelDB for greater resilience
+
+## RPCs
+
+No RPC have changed
+
+## Configuration options
+
+Quick configuration is now split out from the main file and the
+standard `bitmarkd.conf` uses `bitmarkd.conf.sub` to perform the
+configuration setup.
+
+Just fill out a minimum set of global values in `bitmarkd.conf`
+including these values:
+
+* the chain, normally "bitmark"
+* payment addresses for Bitcoin and Litecoin
+* a list of announce IP addresss, one each oof IPv4 and IPv6.
+
+The payment mode is set to **p2p** by default but can be overridden by defining the `payment_mode` variable.  The following modes are supported:
+
+* **p2p** connect to a small subset of Bitcoin/Litecoin peers to
+  receive blocks directly.  This has redundant connections and is the
+  default setting.
+* **rest** connect to a local bitcoind/litecoind rest interface to
+  poll for blocks this should only be over a lan to avoid connection problems as there is no redundacy.
+* **noverify** do not verify payments, this is suitable for a query-only node.
+* **discovery** connect to discovery proxy.  **This option will be removed in a future version.**
+
+
+# Change log
+
+See the `debian/changelog` file for a complete list.

--- a/rpc/setup.go
+++ b/rpc/setup.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/rpc"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -195,6 +196,13 @@ process_rpcs:
 		} else {
 			listen = strings.Split(listen, ":")[0]
 			ipType[i] = "tcp4"
+		}
+		// override for OS with dual stack
+		switch runtime.GOOS {
+		case "freebsd", "linux":
+			ipType[i] = "tcp"
+
+		default:
 		}
 		ip := net.ParseIP(listen)
 		if nil == ip {

--- a/testing/bm-tester
+++ b/testing/bm-tester
@@ -142,9 +142,21 @@ rec:run-recorderd
     fi
     n=$((n + 1))
   done
+  
+  case "$(uname)" in
+    (FreeBSD|DragonFly)
+      top="top:top,-U,${USER},-o,res,-n,20,-i"
+      ;;
+      (Linux)
+      top="top:top,-U,${USER},-o,RES,-n,20,-i"
+      ;;
+    (*)
+      top="top::"
+      ;;
+  esac
 
   # some status tabs and an extra shell
-  command_list="${command_list} info:node-info,-r top:top,-U,${USER},-o,res,-n,20,-i cmd:: shell::"
+  command_list="${command_list} info:node-info,-r ${top} cmd:: shell::"
 
   target=''
   for command in ${command_list}


### PR DESCRIPTION
Rename node type from servant/client to server.client
    
+ Configuration file:  server/client
 
     ``` 
          -- set node types (server|client)    
         -    nodetype = "server",
     ```

+  P2P define NodeType  variable has a   nodeType type

    ```
       type nodeType string
   	NodeType     nodeType
    ```
+ Define const for availible choices

    ```
     const (
         	ServerNode nodeType = "server"
	       ClientNode nodeType = "client"
          )
   ```
      
