### PR TITLE
fix  ipv4 to ipv6 mapping issue on different OS

### DIFF
--- a/command/bitmarkd/bitmarkd.conf.sub
+++ b/command/bitmarkd/bitmarkd.conf.sub
@@ -60,7 +60,8 @@ end
 -- port selections based on chain selected
 -- bitmark:  XXXX
 -- testing: 1XXXX
--- local:   2XXXX
+-- local:   2XXXX 
+-- use "*" for listen all on both ipv4 and ipv6
 function add_port(ip, port)
     local port_base = 20000
     local port_offset = 0 -- special setting to run multiple bitmarkds
@@ -72,12 +73,10 @@ function add_port(ip, port)
     end
     local suffix = ":" .. (port_base + port_offset + port)
     -- check for dual stack OS (via global os_name)
-    -- and listen on either "[::]" or "0.0.0.0"
+    -- and listen on either "[::]" or "0.0.0.0" 
     if ip == "*" then
-        if os_name == "freebsd" then
+        if os_name == "freebsd" or  os_name == "linux" then
             return "[::]" .. suffix
-        elseif os_name == "linux" then
-            return "0.0.0.0" .. suffix
         end
         -- OS has separate IPv4 and IPv6 so need both
         return "[::]" .. suffix, "0.0.0.0" .. suffix
@@ -148,7 +147,9 @@ M.client_rpc = {
     bandwidth = 25000000,
 
     listen = {
-        add_port("*", 2130),
+        -- NOTICE: use "*" for listen all on both ipv4 and ipv6
+       add_port("*", 2130),
+       --  add_port("0.0.0.0", 2130),
     },
 
     -- announce certain public IP:ports to network
@@ -214,9 +215,12 @@ M.peering = {
     prefer_ipv6 = prefer_ipv6,
 
     -- for incoming peer connections
-    listen = {
+      listen = {
+        -- NOTICE: use "*" for listen all on both ipv4 and ipv6
         add_port("*", 2136),
+        -- add_port("0.0.0.0", 2136)
     },
+
 
     -- announce certain public IP:ports to network
     -- if using firewall port forwarding use the firewall external IP:port

--- a/rpc/setup.go
+++ b/rpc/setup.go
@@ -193,16 +193,15 @@ process_rpcs:
 		if '[' == listen[0] {
 			listen = strings.Split(listen[1:], "]:")[0]
 			ipType[i] = "tcp6"
+			// override for OS with dual stack
+			switch runtime.GOOS {
+			case "freebsd", "linux":
+				ipType[i] = "tcp"
+			default:
+			}
 		} else {
 			listen = strings.Split(listen, ":")[0]
 			ipType[i] = "tcp4"
-		}
-		// override for OS with dual stack
-		switch runtime.GOOS {
-		case "freebsd", "linux":
-			ipType[i] = "tcp"
-
-		default:
 		}
 		ip := net.ParseIP(listen)
 		if nil == ip {


### PR DESCRIPTION
freeBSD and linux in tls and zeroMQ library level will do ipv4 to ipv6 mapping. 
For listening all on both ipv4 and ipv6 in freeBSD and Linux, 
We make it listen on IPV6
This affects on : 
Configuration Add port 
RPC TLS network type
Peer package will not be affected because configuration has already taken care of it