### PR TITLE
[command,p2p] rename the peer key configuration item

### DIFF
--- a/command/bitmarkd/bitmarkd.conf.sub
+++ b/command/bitmarkd/bitmarkd.conf.sub
@@ -199,12 +199,12 @@ M.https_rpc = {
     private_key = read_file("rpc.key")
 }
 
-
 -- peer-to-peer connections
 M.peering = {
 
     -- set node type (server|client)
     -- this will be set to "server" if announcing any public IPs
+    -- (see code below)
     nodetype = "client",
 
     -- for incoming peer connections
@@ -224,7 +224,7 @@ M.peering = {
         -- or if PUBLIC_IPV[46] variables are set
         make_announcements(2136),
     },
-    private_key = read_file("peer.secret"),
+    secret_key = read_file("peer.secret"),
 }
 
 -- automatically set node type (server|client)

--- a/command/bitmarkd/commands.go
+++ b/command/bitmarkd/commands.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	peerPrivateKeyFilename = "peer.secret"
+	peerSecretKeyFilename = "peer.secret"
 
 	publishingPublicKeyFilename  = "publishing.public"
 	publishingPrivateKeyFilename = "publishing.private"
@@ -59,26 +59,26 @@ func processSetupCommand(program string, arguments []string) bool {
 
 	switch command {
 	case "gen-peer-identity", "peer":
-		peerPrivateKeyPath := getFilenameWithDirectory(arguments, peerPrivateKeyFilename)
+		peerSecretKeyPath := getFilenameWithDirectory(arguments, peerSecretKeyFilename)
 		publishingPublicKeyPath := getFilenameWithDirectory(arguments, publishingPublicKeyFilename)
 		publishingPrivateKeyPath := getFilenameWithDirectory(arguments, publishingPrivateKeyFilename)
 
 		// the peer secret file
-		if util.EnsureFileExists(peerPrivateKeyPath) {
-			fmt.Printf("generate private key: %q error: %s\n", peerPrivateKeyFilename, fault.KeyFileAlreadyExists)
+		if util.EnsureFileExists(peerSecretKeyPath) {
+			fmt.Printf("generate private key: %q error: %s\n", peerSecretKeyFilename, fault.KeyFileAlreadyExists)
 			exitwithstatus.Exit(1)
 		}
 
 		key, err := util.MakeEd25519PeerKey()
 		if err != nil {
-			fmt.Printf("generate private key: %q error: %s\n", peerPrivateKeyFilename, err.Error())
+			fmt.Printf("generate private key: %q error: %s\n", peerSecretKeyFilename, err.Error())
 			exitwithstatus.Exit(1)
 		}
 
-		err = ioutil.WriteFile(peerPrivateKeyPath, []byte(key+"\n"), 0600)
+		err = ioutil.WriteFile(peerSecretKeyPath, []byte(key+"\n"), 0600)
 		if nil != err {
-			os.Remove(peerPrivateKeyPath)
-			fmt.Printf("generate private key: %q error: %s\n", peerPrivateKeyFilename, err.Error())
+			os.Remove(peerSecretKeyPath)
+			fmt.Printf("generate private key: %q error: %s\n", peerSecretKeyFilename, err.Error())
 			exitwithstatus.Exit(1)
 		}
 
@@ -89,7 +89,7 @@ func processSetupCommand(program string, arguments []string) bool {
 			exitwithstatus.Exit(1)
 		}
 
-		fmt.Printf("generated peer private key: %q\n", peerPrivateKeyFilename)
+		fmt.Printf("generated peer private key: %q\n", peerSecretKeyFilename)
 		fmt.Printf("generated publishing private key: %q and publishing public key: %q\n", publishingPrivateKeyPath, publishingPublicKeyPath)
 
 	case "gen-rpc-cert", "rpc":
@@ -174,7 +174,7 @@ func processSetupCommand(program string, arguments []string) bool {
 		fmt.Printf("  help                       (h)      - display this message\n\n")
 		fmt.Printf("  version                    (v)      - display version sting\n\n")
 
-		fmt.Printf("  gen-peer-identity [DIR]    (peer)   - create peer private key in: %q,\n", "DIR/"+peerPrivateKeyFilename)
+		fmt.Printf("  gen-peer-identity [DIR]    (peer)   - create peer private key in: %q,\n", "DIR/"+peerSecretKeyFilename)
 		fmt.Printf("                                        publishing private key in: %q\n", "DIR/"+publishingPrivateKeyFilename)
 		fmt.Printf("                                        and publishing public key in: %q\n", "DIR/"+publishingPublicKeyFilename)
 		fmt.Printf("\n")
@@ -404,9 +404,9 @@ func dnsTXT(options *Configuration) {
 
 	peering := options.Peering
 
-	privateKey, err := util.DecodePrivKeyFromHex(peering.PrivateKey)
+	privateKey, err := util.DecodePrivKeyFromHex(peering.SecretKey)
 	if err != nil {
-		exitwithstatus.Message("error: cannot decode private key: %q  error: %s", peering.PrivateKey, err)
+		exitwithstatus.Message("error: cannot decode private key: %q  error: %s", peering.SecretKey, err)
 	}
 
 	peerID, err := peer.IDFromPrivateKey(privateKey)

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -33,7 +33,7 @@ func (n *Node) Setup(configuration *Configuration, version string, dnsPeerOnly d
 	}
 	maAddrs := util.IPPortToMultiAddr(listenIPPorts)
 	n.Registers = NewRegistration(registerExpireTime)
-	prvKey, err := util.DecodePrivKeyFromHex(configuration.PrivateKey) //Hex Decoded binaryString
+	prvKey, err := util.DecodePrivKeyFromHex(configuration.SecretKey) //Hex Decoded binaryString
 	if err != nil {
 		return err
 	}

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -35,10 +35,10 @@ func TestMain(m *testing.M) {
 func TestIDMarshalUnmarshal(t *testing.T) {
 	conf, err := mockConfiguration("server", 12136)
 	assert.NoError(t, err, "generate mock data error")
-	prvKey, err := util.DecodePrivKeyFromHex(conf.PrivateKey)
+	secretKey, err := util.DecodePrivKeyFromHex(conf.SecretKey)
 	assert.NoError(t, err, "Decode Hex Key Error")
-	id, err := peerlib.IDFromPrivateKey(prvKey)
-	assert.NoError(t, err, "IDFromPrivateKey Error")
+	id, err := peerlib.IDFromPrivateKey(secretKey)
+	assert.NoError(t, err, "IDFromSecretKey Error")
 	mID, err := id.Marshal()
 	assert.NoError(t, err, "ID Marshal Error:")
 	id2, err := peerlib.IDFromBytes(mID)
@@ -87,11 +87,11 @@ func mockConfiguration(nType string, port int) (*Configuration, error) {
 	}
 
 	return &Configuration{
-		NodeType:   nType,
-		Port:       port,
-		Listen:     []string{"0.0.0.0:" + portString, "[::]:" + portString},
-		Announce:   []string{"127.0.0.1:" + portString, "[::1]:" + portString},
-		PrivateKey: hexKey,
-		Connect:    []StaticConnection{},
+		NodeType:  nType,
+		Port:      port,
+		Listen:    []string{"0.0.0.0:" + portString, "[::]:" + portString},
+		Announce:  []string{"127.0.0.1:" + portString, "[::1]:" + portString},
+		SecretKey: hexKey,
+		Connect:   []StaticConnection{},
 	}, nil
 }

--- a/p2p/setup.go
+++ b/p2p/setup.go
@@ -75,12 +75,12 @@ type StaticConnection struct {
 // Configuration - a block of configuration data
 // this is read from the configuration file
 type Configuration struct {
-	NodeType   string             `gluamapper:"nodetype" json:"nodetype"`
-	Port       int                `gluamapper:"port" json:"port"`
-	Listen     []string           `gluamapper:"listen" json:"listen"`
-	Announce   []string           `gluamapper:"announce" json:"announce"`
-	PrivateKey string             `gluamapper:"private_key" json:"private_key"`
-	Connect    []StaticConnection `gluamapper:"connect" json:"connect,omitempty"`
+	NodeType  string             `gluamapper:"nodetype" json:"nodetype"`
+	Port      int                `gluamapper:"port" json:"port"`
+	Listen    []string           `gluamapper:"listen" json:"listen"`
+	Announce  []string           `gluamapper:"announce" json:"announce"`
+	SecretKey string             `gluamapper:"secret_key" json:"secret_key"`
+	Connect   []StaticConnection `gluamapper:"connect" json:"connect,omitempty"`
 }
 
 // RegisterStatus is the struct to reflect the register status of a node


### PR DESCRIPTION
renamed from private to secret to avoid confusion with
public/private keys pairs in separate files

Signed-off-by: Christopher Hall <hsw@bitmark.com>