### PR TITLE
Libp2p resend block

### DIFF
--- a/block/blockstore.go
+++ b/block/blockstore.go
@@ -57,8 +57,10 @@ func (blk *blockstore) process(item *messagebus.Message) {
 		packedBlock := item.Parameters[0]
 		err := StoreIncoming(packedBlock, nil, RescanVerified)
 		if nil == err {
-			// broadcast this packedBlock to peers if the block was valid
-			messagebus.Bus.P2P.Send("block", packedBlock)
+			// broadcast this packedBlock to peers if the block was valid (only local)
+			if item.Command == "local" {
+				messagebus.Bus.P2P.Send("block", packedBlock)
+			}
 		} else {
 			log.Debugf("store block: %x  error: %s", packedBlock, err)
 		}


### PR DESCRIPTION
This is a part of fix of  [libp2p] traffic load is unexpected #146 
Fix forcing flooding-broadcasting in block broadcasting
only the node which generates the block using gossip-broadcasting to send it