### PR TITLE
[Fix doc] Wrong example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ bitmarkd --config-file="${HOME}/.config/bitmarkd/bitmarkd.conf" help
 Generate key files and certificates.
 
 ~~~~~
-bitmarkd --config-file="${HOME}/.config/bitmarkd/bitmarkd.conf" gen-peer-identity "${HOME}/.config/bitmarkd/
-bitmarkd --config-file="${HOME}/.config/bitmarkd/bitmarkd.conf" gen-rpc-cert "${HOME}/.config/bitmarkd/
-bitmarkd --config-file="${HOME}/.config/bitmarkd/bitmarkd.conf" gen-proof-identity "${HOME}/.config/bitmarkd/
+bitmarkd --config-file="${HOME}/.config/bitmarkd/bitmarkd.conf" gen-peer-identity "${HOME}/.config/bitmarkd/"
+bitmarkd --config-file="${HOME}/.config/bitmarkd/bitmarkd.conf" gen-rpc-cert "${HOME}/.config/bitmarkd/"
+bitmarkd --config-file="${HOME}/.config/bitmarkd/bitmarkd.conf" gen-proof-identity "${HOME}/.config/bitmarkd/"
 ~~~~~
 
 Start the program.


### PR DESCRIPTION
If there is no `"` command cannot be executed normally